### PR TITLE
Initial GUIDE support

### DIFF
--- a/src/Sage.Engine.Tests/Corpus/Language/guide.txt
+++ b/src/Sage.Engine.Tests/Corpus/Language/guide.txt
@@ -1,0 +1,68 @@
+﻿===========
+Slot
+===========
+Hello
+{{.slot foo}}
+{{/slot}}
+World
+++++++++++
+Hello
+
+
+World
+===========
+Slot HTML Content
+===========
+Hello
+{{.slot foo}}
+This is content
+{{/slot}}
+World
+++++++++++
+Hello
+
+This is content
+
+World
+===========
+Slot AMP Content
+===========
+Hello
+{{.slot foo}}
+%%=ADD(1,2)=%%
+{{/slot}}
+World
+++++++++++
+Hello
+
+3
+
+World
+===========
+Slot Block
+===========
+{{.slot foo}}
+{{.block foo htmlemail}}
+Hello world
+{{/block}}
+{{/slot}}
+++++++++++
+Hello world
+===========
+Slot Block Data
+===========
+{{.slot foo}}
+{{.block foo htmlemail}}
+{{.data}}{
+  "email": {
+    "options": {
+      "generateFrom": ""
+    }
+  }
+}
+{{/data}}
+Hello world
+{{/block}}
+{{/slot}}
+++++++++++
+Hello world

--- a/src/Sage.Engine.Tests/Corpus/Parser/guide.txt
+++ b/src/Sage.Engine.Tests/Corpus/Parser/guide.txt
@@ -1,0 +1,150 @@
+﻿===========
+Slot
+===========
+Hello
+{{.slot foo}}
+{{/slot}}
+World
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (GuideContentContext
+        (GuideSlotTagContext
+          (GuideSlotTagOpenContext)
+          (ContentBlockContext
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext)))
+          (GuideSlotTagCloseContext))))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))
+===========
+Slot HTML Content
+===========
+Hello
+{{.slot foo}}
+This is content
+{{/slot}}
+World
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (GuideContentContext
+        (GuideSlotTagContext
+          (GuideSlotTagOpenContext)
+          (ContentBlockContext
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext)))
+          (GuideSlotTagCloseContext))))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))
+===========
+Slot AMP Content
+===========
+Hello
+{{.slot foo}}
+%%NAME%%
+{{/slot}}
+World
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (GuideContentContext
+        (GuideSlotTagContext
+          (GuideSlotTagOpenContext)
+          (ContentBlockContext
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext))
+            (AmpOrEmbeddedContentContext
+              (AttributeNameAtSeaContext))
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext)))
+          (GuideSlotTagCloseContext))))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))
+
+===========
+Slot Block
+===========
+{{.slot foo}}
+{{.block foo htmlemail}}
+{{/block}}
+{{/slot}}
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (GuideContentContext
+        (GuideSlotTagContext
+          (GuideSlotTagOpenContext)
+          (ContentBlockContext
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext))
+            (AmpOrEmbeddedContentContext
+              (GuideContentContext
+                (GuideBlockTagContext
+                  (GuideBlockTagOpenContext)
+                  (ContentBlockContext
+                    (AmpOrEmbeddedContentContext
+                      (InlineHtmlContext)))
+                  (GuideBlockTagCloseContext))))
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext)))
+          (GuideSlotTagCloseContext))))))
+===========
+Slot Block Data
+===========
+{{.slot foo}}
+{{.block foo htmlemail}}
+{{.data}}{
+  "email": {
+    "options": {
+      "generateFrom": ""
+    }
+  }
+}
+{{/data}}
+{{/block}}
+{{/slot}}
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (GuideContentContext
+        (GuideSlotTagContext
+          (GuideSlotTagOpenContext)
+          (ContentBlockContext
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext))
+            (AmpOrEmbeddedContentContext
+              (GuideContentContext
+                (GuideBlockTagContext
+                  (GuideBlockTagOpenContext)
+                  (ContentBlockContext
+                    (AmpOrEmbeddedContentContext
+                      (InlineHtmlContext))
+                    (AmpOrEmbeddedContentContext
+                      (GuideContentContext
+                        (GuideDataTagContext
+                          (GuideDataTagOpenContext)
+                          (InlineHtmlContext)
+                          (InlineHtmlContext)
+                          (InlineHtmlContext)
+                          (InlineHtmlContext)
+                          (InlineHtmlContext)
+                          (InlineHtmlContext)
+                          (GuideDataTagCloseContext))))
+                    (AmpOrEmbeddedContentContext
+                      (InlineHtmlContext)))
+                  (GuideBlockTagCloseContext))))
+            (AmpOrEmbeddedContentContext
+              (InlineHtmlContext)))
+          (GuideSlotTagCloseContext))))))

--- a/src/Sage.Engine.Tests/Corpus/Parser/inlinehtml.txt
+++ b/src/Sage.Engine.Tests/Corpus/Parser/inlinehtml.txt
@@ -1,0 +1,39 @@
+﻿===========
+Inline HTML Percents
+===========
+This is some Percent % signs.
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))
+===========
+Inline HTML Curly Brace
+===========
+This is some Curly { braces.
+{ 'this': 1, { 'is': 2 }, { 'json': 3 }}
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))

--- a/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
+++ b/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
@@ -117,6 +117,15 @@
     <None Update="Corpus\Function\substring.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Corpus\Language\guide.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Parser\inlinehtml.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Parser\guide.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Corpus\Parser\attributes.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Sage.Engine/Parser/SageLexer.g4
+++ b/src/Sage.Engine/Parser/SageLexer.g4
@@ -9,12 +9,26 @@ options {
     caseInsensitive = true;
 }
 
-HtmlText:       ~[%]+;
+HtmlText:       ~[%{]+;
 SeaWhitespace:  [ \t\r\n]+ -> channel(HIDDEN);
 AmpBlockStart:          '%%['  -> mode(AMP), channel(HIDDEN);
 InlineAmpBlockStart:    '%%='  -> mode(AMP);
 AttributeNameAtSea:    '%%' [a-z_][a-z_0-9 ]* '%%';
 PercentSign:    '%';
+CurlyBrace:     '{';
+GuideTagStart: '{{' -> pushMode(GuideTag);
+
+mode GuideTag;
+GuideWhitespace:            [ \t\r\n]+ -> channel(HIDDEN);
+GuideOpenSlotTagType:       '.slot';
+GuideOpenBlockTagType:      '.block';
+GuideOpenDataTagType:       '.data';
+GuideCloseBlockTagType:     '/block';
+GuideCloseSlotTagType:      '/slot';
+GuideCloseDataTagType:      '/data';
+GuideIdentifier:            [a-z][a-z0-9]*;
+GuideTagEnd:                '}}' -> popMode;
+
 
 mode AMP;
 

--- a/src/Sage.Engine/Parser/SageParser.g4
+++ b/src/Sage.Engine/Parser/SageParser.g4
@@ -22,6 +22,7 @@ attributeNameAtSea
 inlineHtml
     : HtmlText 
     | PercentSign
+    | CurlyBrace
     ;
 
 ampBlock
@@ -42,11 +43,13 @@ ampStatement
 
 ampOrEmbeddedContent
     : ampBlock
+    | guideContent
     | inlineHtml
     | inlineAmpBlock
     | attributeNameAtSea
     ;
 
+// AMPscript
 varDeclaration
     : Var VarName (Comma VarName)*
     ;
@@ -129,3 +132,41 @@ attribute
 arguments
     : OpenParen ( expression (Comma expression)* )? CloseParen
     ;
+
+// Guide
+guideContent
+    : guideSlotTag
+    | guideBlockTag
+    | guideDataTag
+    ;
+
+// {{.data}}
+guideDataTag
+    : guideDataTagOpen inlineHtml* guideDataTagClose;
+
+guideDataTagOpen
+    : GuideTagStart GuideOpenDataTagType GuideTagEnd;
+
+guideDataTagClose
+    : GuideTagStart GuideCloseDataTagType GuideTagEnd;
+
+
+// {{.block}}
+guideBlockTag
+    : guideBlockTagOpen contentBlock guideBlockTagClose;
+
+guideBlockTagOpen
+    : GuideTagStart GuideOpenBlockTagType GuideIdentifier GuideIdentifier GuideTagEnd;
+
+guideBlockTagClose
+    : GuideTagStart GuideCloseBlockTagType GuideTagEnd;
+
+// {{.slot}}
+guideSlotTag
+    : guideSlotTagOpen contentBlock guideSlotTagClose;
+
+guideSlotTagOpen
+    : GuideTagStart GuideOpenSlotTagType GuideIdentifier GuideTagEnd;
+
+guideSlotTagClose
+    : GuideTagStart GuideCloseSlotTagType GuideTagEnd;

--- a/src/Sage.Engine/Transpiler/BlockVisitor.cs
+++ b/src/Sage.Engine/Transpiler/BlockVisitor.cs
@@ -49,6 +49,11 @@ internal class BlockVisitor : SageParserBaseVisitor<IEnumerable<StatementSyntax>
         }
     }
 
+    public override IEnumerable<StatementSyntax> VisitGuideContent(SageParser.GuideContentContext context)
+    {
+        return _transpiler.GuideVisitor.Visit(context);
+    }
+
     /// <summary>
     /// An inline AmpBlock is AMPscript of the form %%= -- for example, %%=V(Firstname)=%%.
     /// </summary>

--- a/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
+++ b/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
@@ -64,6 +64,12 @@ internal class CSharpTranspiler
         get;
     }
 
+
+    internal GuideVisitor GuideVisitor
+    {
+        get;
+    }
+
     private readonly SageParser _parser;
 
     /// <summary>
@@ -76,6 +82,7 @@ internal class CSharpTranspiler
         StatementVisitor = new StatementVisitor(this);
         ExpressionVisitor = new ExpressionVisitor(this);
         StringVisitor = new StringVisitor(this);
+        GuideVisitor = new GuideVisitor(this);
         Runtime = new Runtime();
         IfVisitor = new IfVisitor(this);
         this.SourceFileName = "TEST.cs";

--- a/src/Sage.Engine/Transpiler/GuideVisitor.cs
+++ b/src/Sage.Engine/Transpiler/GuideVisitor.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Sage.Engine.Parser;
+
+namespace Sage.Engine.Transpiler;
+
+/// <summary>
+/// This holds all GUIDE visitors.
+///
+/// There may be a time that GUIDE visitors are more complex, but today is not that day for simple GUIDE support found in default content templates.
+/// </summary>
+internal class GuideVisitor : SageParserBaseVisitor<IEnumerable<StatementSyntax>>
+{
+    private readonly CSharpTranspiler _transpiler;
+
+    public GuideVisitor(CSharpTranspiler transpiler)
+    {
+        this._transpiler = transpiler;
+    }
+
+    public override IEnumerable<StatementSyntax> VisitGuideSlotTag(SageParser.GuideSlotTagContext context)
+    {
+        return _transpiler.BlockVisitor.VisitContentBlock(context.contentBlock());
+    }
+
+    public override IEnumerable<StatementSyntax> VisitGuideDataTag(SageParser.GuideDataTagContext context)
+    {
+        return Enumerable.Empty<StatementSyntax>();
+    }
+
+    public override IEnumerable<StatementSyntax> VisitGuideBlockTag(SageParser.GuideBlockTagContext context)
+    {
+        return _transpiler.BlockVisitor.VisitContentBlock(context.contentBlock());
+    }
+}


### PR DESCRIPTION
This change adds initial GUIDE support.

Supported is resolving the minimal amount of GUIDE that is generated from standard templates after message compilation.

Included in support are the following:
{{.slot identifier}}{{/slot}}

{{.block identifier asset_type}}{{/block}}

{{.data}}{{/data}}