### PR TITLE
HTML script tag syntax support

### DIFF
--- a/src/Sage.Engine.Tests/Corpus/Language/script-tags.txt
+++ b/src/Sage.Engine.Tests/Corpus/Language/script-tags.txt
@@ -1,0 +1,20 @@
+﻿===========
+AMPscript script tags
+===========
+<script runat="server" language="ampscript">
+SET @foo = 1
+</script>
+%%=V(@foo)=%%
+++++++++++
+1
+===========
+Slot
+===========
+<script runat="server" language="javascript">
+SET @foo = 1
+</script>
+%%=V(@foo)=%%
+++++++++++
+<script runat="server" language="javascript">
+SET @foo = 1
+</script>

--- a/src/Sage.Engine.Tests/Corpus/Parser/inlinehtml.txt
+++ b/src/Sage.Engine.Tests/Corpus/Parser/inlinehtml.txt
@@ -6,10 +6,8 @@ This is some Percent % signs.
 (ContentBlockFileContext
   (ContentBlockContext
     (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext)
+      (InlineHtmlContext)
       (InlineHtmlContext))))
 ===========
 Inline HTML Curly Brace
@@ -20,20 +18,33 @@ This is some Curly { braces.
 (ContentBlockFileContext
   (ContentBlockContext
     (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext))))
+===========
+Inline HTML Tags
+===========
+<html>
+<head></head>
+<br/>
+</html>
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
     (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
-      (InlineHtmlContext))
-    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext)
       (InlineHtmlContext))))

--- a/src/Sage.Engine.Tests/Corpus/Parser/script-tags.txt
+++ b/src/Sage.Engine.Tests/Corpus/Parser/script-tags.txt
@@ -1,0 +1,96 @@
+﻿===========
+Basic script tags
+===========
+<script language="ampscript" runat="server">
+</script>
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext
+        (ScriptTagContext)))))
+===========
+Basic script tags with AMPscript
+===========
+<script language="ampscript" runat="server">
+SET @FOO = 1
+</script>
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext
+        (ScriptTagContext)))
+    (AmpOrEmbeddedContentContext
+      (AmpBlockContext
+        (AmpStatementContext
+          (SetVariableContext
+            (VariableAssignmentContext
+              (ConstantExpressionContext
+                (ConstantContext)))))))))
+===========
+Basic script tags with multiple AMPscript
+===========
+<script language="ampscript" runat="server">
+SET @FOO = 1
+</script>
+This is more stuff
+<script language="ampscript" runat="server">
+SET @FOO = 2
+</script>
+This is more
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext
+        (ScriptTagContext)))
+    (AmpOrEmbeddedContentContext
+      (AmpBlockContext
+        (AmpStatementContext
+          (SetVariableContext
+            (VariableAssignmentContext
+              (ConstantExpressionContext
+                (ConstantContext)))))))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext)
+      (InlineHtmlContext
+        (ScriptTagContext)))
+    (AmpOrEmbeddedContentContext
+      (AmpBlockContext
+        (AmpStatementContext
+          (SetVariableContext
+            (VariableAssignmentContext
+              (ConstantExpressionContext
+                (ConstantContext)))))))
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext))))
+===========
+Non Ampscript Tags
+===========
+<script language="Javascript" runat="server"></script>
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext
+        (ScriptTagContext))
+      (InlineHtmlContext)
+      (InlineHtmlContext))))
+      
+===========
+Javascript Code
+===========
+<script runat="server" language="javascript">
+This is some javascript
+</script>
+----------
+(ContentBlockFileContext
+  (ContentBlockContext
+    (AmpOrEmbeddedContentContext
+      (InlineHtmlContext
+        (ScriptTagContext))
+      (InlineHtmlContext)
+      (InlineHtmlContext)
+      (InlineHtmlContext))))
+      

--- a/src/Sage.Engine.Tests/ParserTests.cs
+++ b/src/Sage.Engine.Tests/ParserTests.cs
@@ -11,7 +11,7 @@ namespace Sage.Engine.Tests
     /// These tests validate that the ANTLR4 generated parse tree is what is expected from test files
     /// </summary>
     [TestFixture]
-    public class ParserTests
+    public class ParserTests : SageTest
     {
         [Test]
         [ParserTest("Parser")]

--- a/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
+++ b/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
@@ -117,6 +117,9 @@
     <None Update="Corpus\Function\substring.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Corpus\Language\script-tags.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Corpus\Language\guide.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -142,6 +145,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Corpus\Parser\if.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Parser\script-tags.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="DataExtensions\Loyalty.csv">

--- a/src/Sage.Engine.Tests/SageTest.cs
+++ b/src/Sage.Engine.Tests/SageTest.cs
@@ -54,7 +54,7 @@ namespace Sage.Engine.Tests
         /// </summary>
         public static void AssertEqualGeneratedCode<TNode>(TNode actual, string expected) where TNode : SyntaxNode
         {
-            Assert.That(actual.NormalizeWhitespace(eol: "\n").ToFullString(), Is.EqualTo(expected));
+            Assert.That(actual.NormalizeWhitespace(eol: "\n").ToFullString(), Is.EqualTo(expected.ReplaceLineEndings("\n")));
         }
     }
 }

--- a/src/Sage.Engine.Tests/TestUtils.cs
+++ b/src/Sage.Engine.Tests/TestUtils.cs
@@ -21,7 +21,7 @@ public static class TestUtils
     {
         ParserTestResult result;
 
-        IParseTree parseTree = AntlrParser.Parse(test.Code, null, null);
+        IParseTree parseTree = AntlrParser.Parse(test.Code, Console.Out, Console.Error);
         string serializedTree = AntlrParser.SerializeTree(parseTree);
         result = new ParserTestResult(serializedTree);
 

--- a/src/Sage.Engine.Tests/TranspilerTests.cs
+++ b/src/Sage.Engine.Tests/TranspilerTests.cs
@@ -4,8 +4,8 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
 namespace Sage.Engine.Tests
-{ using Antlr4.Runtime;
-    using Microsoft.CodeAnalysis;
+{
+    using Antlr4.Runtime;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using NUnit.Framework;
     using Parser;
@@ -152,8 +152,10 @@ namespace Sage.Engine.Tests
         [Test]
         [TestCase("FOR @I=1 TO 10 DO VAR @VAR NEXT @I", new[]
         {
-            $"#line (1, 5) - (1, 9) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@i\", SageValue.ToLong(1L));",
-            $"#line (1, 13) - (1, 15) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"__for_target_@i_1\", SageValue.ToLong(10L));",
+            @$"#line (1, 5) - (1, 9) ""TEST.cs""
+{Runtime.RuntimeVariable}.SetVariable(""@i"", SageValue.ToLong(1L));",
+            @$"#line (1, 13) - (1, 15) ""TEST.cs""
+{Runtime.RuntimeVariable}.SetVariable(""__for_target_@i_1"", SageValue.ToLong(10L));",
             @$"#line (1, 1) - (1, 18) ""TEST.cs""
 while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) <= SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""__for_target_@i_1"")))
 {{
@@ -170,8 +172,10 @@ while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) <= SageVa
         })]
         [TestCase("FOR @I=10 DOWNTO 1 DO VAR @VAR NEXT @I", new[]
         {
-            $"#line (1, 5) - (1, 10) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@i\", SageValue.ToLong(10L));",
-            $"#line (1, 18) - (1, 19) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"__for_target_@i_1\", SageValue.ToLong(1L));",
+            @$"#line (1, 5) - (1, 10) ""TEST.cs""
+{Runtime.RuntimeVariable}.SetVariable(""@i"", SageValue.ToLong(10L));",
+            @$"#line (1, 18) - (1, 19) ""TEST.cs""
+{Runtime.RuntimeVariable}.SetVariable(""__for_target_@i_1"", SageValue.ToLong(1L));",
             @$"#line (1, 1) - (1, 22) ""TEST.cs""
 while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) >= SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""__for_target_@i_1"")))
 {{

--- a/src/Sage.Engine/Parser/AmpscriptLexerBase.cs
+++ b/src/Sage.Engine/Parser/AmpscriptLexerBase.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2023, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Antlr4.Runtime;
+
+namespace Sage.Engine.Parser
+{
+    /// <summary>
+    /// This class is a helper class for the lexer to assist in complex lexing tasks.
+    ///
+    /// For the moment, this is meant to identify when HTML scrip tags are AMPscript tags,
+    /// in order to support the HTML script tag syntax. (See: https://ampscript.guide/tag-based-syntax/)
+    /// </summary>
+    public abstract class AmpscriptLexerBase : Lexer
+    {
+        protected string _htmlNameText;
+        protected bool _ampscriptScript;
+
+        protected AmpscriptLexerBase(ICharStream input, TextWriter output, TextWriter errorOutput)
+            : base(input, output, errorOutput)
+        {
+        }
+
+        /// <summary>
+        /// Determines if the script tag contained "ampscript", and if it did
+        /// then change the mode to AMP
+        /// </summary>
+        public override IToken NextToken()
+        {
+            CommonToken token = (CommonToken)base.NextToken();
+
+            if (token.Type == SageLexer.HtmlName)
+            {
+                _htmlNameText = token.Text;
+            }
+            else if (token.Type == SageLexer.HtmlDoubleQuoteString)
+            {
+                if (string.Equals(token.Text, "ampscript", System.StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(_htmlNameText, "language"))
+                {
+                    _ampscriptScript = true;
+                }
+            }
+
+            return token;
+        }
+
+        /// <summary>
+        /// When the lexer identifies a closing tag for HTML, it'll invoke this.
+        ///
+        /// This will then use the logic from above to determine if the language was AMPscript,
+        /// and if so, put the lexer in AMP mode.
+        /// </summary>
+        protected void PushModeOnHtmlClose()
+        {
+            PopMode();
+            if (_ampscriptScript)
+            {
+                PushMode(SageLexer.AMP);
+                _ampscriptScript = false;
+            }
+        }
+    }
+}

--- a/src/Sage.Engine/Parser/Parser.cs
+++ b/src/Sage.Engine/Parser/Parser.cs
@@ -10,7 +10,7 @@ namespace Sage.Engine.Parser;
 
 public static class AntlrParser
 {
-    public static IParseTree Parse(string code, TextWriter? outputStream, TextWriter? errorStream)
+    public static IParseTree Parse(string code, TextWriter outputStream, TextWriter errorStream)
     {
         var stream = new AntlrInputStream(code);
         var lexer = new SageLexer(stream, outputStream, errorStream);

--- a/src/Sage.Engine/Parser/SageParser.g4
+++ b/src/Sage.Engine/Parser/SageParser.g4
@@ -21,8 +21,25 @@ attributeNameAtSea
 
 inlineHtml
     : HtmlText 
+    | scriptTag
+    | HtmlOpen
+    | HtmlSpace
+    | HtmlScriptClose
     | PercentSign
     | CurlyBrace
+    | SeaLessThan
+    ;
+
+scriptTag
+    : HtmlScriptOpen (HtmlEquals
+    | HtmlStartQuoteString
+    | HtmlStartDoubleQuoteString
+    | HtmlName
+    | HtmlEndQuoteString
+    | HtmlQuoteString
+    | HtmlEndDoubleQuoteString
+    | HtmlDoubleQuoteString
+    | HtmlSpace)+ HtmlClose
     ;
 
 ampBlock
@@ -44,7 +61,7 @@ ampStatement
 ampOrEmbeddedContent
     : ampBlock
     | guideContent
-    | inlineHtml
+    | inlineHtml+
     | inlineAmpBlock
     | attributeNameAtSea
     ;

--- a/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
+++ b/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
@@ -70,6 +70,11 @@ internal class CSharpTranspiler
         get;
     }
 
+    public HtmlVisitor HtmlVisitor
+    {
+        get;
+    }
+
     private readonly SageParser _parser;
 
     /// <summary>
@@ -83,6 +88,7 @@ internal class CSharpTranspiler
         ExpressionVisitor = new ExpressionVisitor(this);
         StringVisitor = new StringVisitor(this);
         GuideVisitor = new GuideVisitor(this);
+        HtmlVisitor = new HtmlVisitor(this);
         Runtime = new Runtime();
         IfVisitor = new IfVisitor(this);
         this.SourceFileName = "TEST.cs";

--- a/src/Sage.Engine/Transpiler/HtmlVisitor.cs
+++ b/src/Sage.Engine/Transpiler/HtmlVisitor.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using System.Text;
+using Antlr4.Runtime.Tree;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Sage.Engine.Parser;
+
+namespace Sage.Engine.Transpiler;
+
+/// <summary>
+/// A special visitor to handle inline HTML and the scripting tags.
+/// </summary>
+internal class HtmlVisitor : SageParserBaseVisitor<IEnumerable<StatementSyntax>>
+{
+    private readonly CSharpTranspiler _transpiler;
+
+    public HtmlVisitor(CSharpTranspiler transpiler)
+    {
+        this._transpiler = transpiler;
+    }
+
+    protected override IEnumerable<StatementSyntax> AggregateResult(IEnumerable<StatementSyntax> aggregate, IEnumerable<StatementSyntax> nextResult)
+    {
+        var next = nextResult ?? Enumerable.Empty<StatementSyntax>();
+        return aggregate?.Concat(next) ?? next;
+    }
+
+    /// <summary>
+    /// A script tag may or may not want to be emitted.
+    ///
+    /// If it was an AMPscript script tag, then it shouldn't be emitted.  All other script tags should be emitted.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public override IEnumerable<StatementSyntax> VisitScriptTag(SageParser.ScriptTagContext context)
+    {
+        foreach (var child in context.children)
+        {
+            if (context.GetText().Contains("ampscript", StringComparison.OrdinalIgnoreCase))
+            {
+                return Enumerable.Empty<StatementSyntax>();
+            }
+        }
+        StringBuilder builder = new StringBuilder();
+
+        foreach (var child in context.children)
+        {
+            builder.Append(child.GetText());
+        }
+
+        return new[]
+        {
+            _transpiler.Runtime.EmitToOutputStream(builder.ToString())
+        };
+    }
+
+    /// <summary>
+    /// By default, all terminal nodes from inline HTML should be emitted to the output stream.
+    ///
+    /// The only special case is the scripting tags, which is handled above.
+    /// </summary>
+    public override IEnumerable<StatementSyntax> VisitTerminal(ITerminalNode node)
+    {
+        return new[]
+        {
+            _transpiler.Runtime.EmitToOutputStream(node.GetText())
+        };
+    }
+}


### PR DESCRIPTION
This change introduces the ability to support HTML tag style of AMPscript using script tags.

Minor other improvements to the grammar and tests.

Notes on the support:
* Must use double quotes - e.g. language="ampscript"