### PR TITLE
Improved line attribution

### DIFF
--- a/src/Sage.Engine.Tests/SageTest.cs
+++ b/src/Sage.Engine.Tests/SageTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Sage.Engine.DependencyInjection;
 using Sage.Engine.Extensions;
@@ -52,8 +53,12 @@ namespace Sage.Engine.Tests
         /// <summary>
         /// Encapsulates how the test validates the code is identical between generated and expected code.
         /// </summary>
-        public static void AssertEqualGeneratedCode<TNode>(TNode actual, string expected) where TNode : SyntaxNode
+        public static void AssertEqualGeneratedCode<TNode>(TNode actual, string expected, bool withTrivia = true) where TNode : SyntaxNode
         {
+            if (!withTrivia)
+            {
+                actual = actual.WithoutTrivia();
+            }
             Assert.That(actual.NormalizeWhitespace(eol: "\n").ToFullString(), Is.EqualTo(expected.ReplaceLineEndings("\n")));
         }
     }

--- a/src/Sage.Engine.Tests/TranspilerTests.cs
+++ b/src/Sage.Engine.Tests/TranspilerTests.cs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using Microsoft.CodeAnalysis;
+
 namespace Sage.Engine.Tests
 {
     using Antlr4.Runtime;
@@ -60,9 +62,9 @@ namespace Sage.Engine.Tests
         }
 
         [Test]
-        [TestCase("SET @FOO = 1", $"{Runtime.RuntimeVariable}.SetVariable(\"@foo\", 1L);")]
-        [TestCase("SET @BAR = 'Foo'", $"{Runtime.RuntimeVariable}.SetVariable(\"@bar\", \"Foo\");")]
-        [TestCase("SET @BAR = @FOO", $"{Runtime.RuntimeVariable}.SetVariable(\"@bar\", {Runtime.RuntimeVariable}.GetVariable(\"@foo\"));")]
+        [TestCase("SET @FOO = 1", $"#line (1, 1) - (1, 13) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@foo\", 1L);")]
+        [TestCase("SET @BAR = 'Foo'", $"#line (1, 1) - (1, 17) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@bar\", \"Foo\");")]
+        [TestCase("SET @BAR = @FOO", $"#line (1, 1) - (1, 16) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@bar\", {Runtime.RuntimeVariable}.GetVariable(\"@foo\"));")]
         public void TestSet(string code, string expected)
         {
             SageParser parser = GetParserInAmpMode(code);
@@ -86,7 +88,7 @@ namespace Sage.Engine.Tests
             string cSharpCodeExpected = $"{Runtime.RuntimeVariable}.SetVariable(\"@foo\", {cSharpExpected});";
             SageParser parser = GetParserInAmpMode(ampCodeInput);
             var transpiler = new CSharpTranspiler(parser);
-            TestAmpCodeGeneratesExpectedCSharpCode(new[] { cSharpCodeExpected }, parser.setVariable(), transpiler.StatementVisitor);
+            TestAmpCodeGeneratesExpectedCSharpCode(new[] { cSharpCodeExpected }, parser.setVariable(), transpiler.StatementVisitor, withTrivia: false);
         }
 
         [Test]
@@ -110,7 +112,7 @@ namespace Sage.Engine.Tests
         [Test]
         [TestCase("%%[ SET @FOO = 'bar' ]%%", new[]
         {
-            $"{Runtime.RuntimeVariable}.SetVariable(\"@foo\", \"bar\");",
+            $"#line (1, 5) - (1, 21) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@foo\", \"bar\");",
         })]
         public void TestAmpBlock(string code, string[] expectedCode)
         {
@@ -158,6 +160,7 @@ namespace Sage.Engine.Tests
 {Runtime.RuntimeVariable}.SetVariable(""__for_target_@i_1"", SageValue.ToLong(10L));",
             @$"#line (1, 1) - (1, 18) ""TEST.cs""
 while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) <= SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""__for_target_@i_1"")))
+#line hidden
 {{
 #line (1, 19) - (1, 27) ""TEST.cs""
     {Runtime.RuntimeVariable}.SetVariable(""@var"", null);
@@ -165,9 +168,12 @@ while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) <= SageVa
     {Runtime.RuntimeVariable}.SetVariable(""@i"", ((long){Runtime.RuntimeVariable}.GetVariable(""@i"").Value) + 1);
 #line hidden
     if (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) == long.MaxValue)
+#line hidden
     {{
         break;
+#line hidden
     }}
+#line hidden
 }}"
         })]
         [TestCase("FOR @I=10 DOWNTO 1 DO VAR @VAR NEXT @I", new[]
@@ -178,6 +184,7 @@ while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) <= SageVa
 {Runtime.RuntimeVariable}.SetVariable(""__for_target_@i_1"", SageValue.ToLong(1L));",
             @$"#line (1, 1) - (1, 22) ""TEST.cs""
 while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) >= SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""__for_target_@i_1"")))
+#line hidden
 {{
 #line (1, 23) - (1, 31) ""TEST.cs""
     {Runtime.RuntimeVariable}.SetVariable(""@var"", null);
@@ -185,9 +192,12 @@ while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) >= SageVa
     {Runtime.RuntimeVariable}.SetVariable(""@i"", ((long){Runtime.RuntimeVariable}.GetVariable(""@i"").Value) - 1);
 #line hidden
     if (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) == long.MinValue)
+#line hidden
     {{
         break;
+#line hidden
     }}
+#line hidden
 }}"
         })]
         public void TestForLoop(string ampCode, string[] cSharpStatements)
@@ -200,29 +210,40 @@ while (SageValue.ToLong({Runtime.RuntimeVariable}.GetVariable(""@i"")) >= SageVa
         [Test]
         [TestCase("IF (true) THEN ENDIF", new[] { @"#line (1, 1) - (1, 15) ""TEST.cs""
 if (true)
+#line hidden
 {
+#line hidden
 }" })]
         [TestCase("IF (true) THEN ELSEIF (false) THEN ENDIF", new[] { @"#line (1, 1) - (1, 15) ""TEST.cs""
 if (true)
+#line hidden
 {
+#line hidden
 }
 else 
-#line (1, 16) - (1, 35) ""TEST.cs""
+#line (1, 23) - (1, 30) ""TEST.cs""
 if (false)
+#line hidden
 {
+#line hidden
 }" })]
         [TestCase("IF (true) THEN ELSEIF (false) THEN ELSE ENDIF", new[] { @"#line (1, 1) - (1, 15) ""TEST.cs""
 if (true)
+#line hidden
 {
+#line hidden
 }
 else 
-#line (1, 16) - (1, 35) ""TEST.cs""
+#line (1, 23) - (1, 30) ""TEST.cs""
 if (false)
+#line hidden
 {
+#line hidden
 }
-#line (1, 36) - (1, 40) ""TEST.cs""
 else
+#line hidden
 {
+#line hidden
 }" })]
         public void TestIfStatement(string ampCode, string[] cSharpStatements)
         {
@@ -234,7 +255,7 @@ else
         [Test]
         [TestCase("%%[ SET @VAR = [Foo] ]%%", new[]
         {
-            $"{Runtime.RuntimeVariable}.SetVariable(\"@var\", {Runtime.RuntimeVariable}.ATTRIBUTEVALUE(\"Foo\"));"
+            $"#line (1, 5) - (1, 21) \"TEST.cs\"\n{Runtime.RuntimeVariable}.SetVariable(\"@var\", {Runtime.RuntimeVariable}.ATTRIBUTEVALUE(\"Foo\"));"
         })]
         [TestCase("HELLO %%Foo%%", new[]
         {
@@ -252,21 +273,33 @@ else
         public void TestGeneratedMethod()
         {
             var transpiler = CSharpTranspiler.CreateFromSource("%%[VAR @FOO]%%");
-            
+
             SageTest.AssertEqualGeneratedCode(transpiler.GenerateMethodFromCode("Foo"), @$"#line hidden
 public static void Foo(RuntimeContext __runtime)
+#line hidden
 {{
 #line (1, 4) - (1, 12) ""TEST""
     {Runtime.RuntimeVariable}.SetVariable(""@foo"", null);
+#line hidden
 }}");
         }
 
         private static void TestAmpCodeGeneratesExpectedCSharpCode(
             string[] expectedCSharpCode,
             ParserRuleContext context,
-            SageParserBaseVisitor<IEnumerable<StatementSyntax>> statementVisitor)
+            SageParserBaseVisitor<IEnumerable<StatementSyntax>> statementVisitor,
+            bool withTrivia = true)
         {
-            var actualCode = statementVisitor.Visit(context).ToArray();
+
+            var actualCode = statementVisitor.Visit(context).Select(s =>
+            {
+                if (!withTrivia)
+                {
+                    return s.WithoutTrivia();
+                }
+
+                return s;
+            }).ToArray();
 
             Assert.That(actualCode.Length, Is.EqualTo(expectedCSharpCode.Length),
                 "Number of generated statements does not match the number of cSharpExpected statements");
@@ -291,9 +324,11 @@ public static void Foo(RuntimeContext __runtime)
     {{
 #line hidden
         public static void TEST(RuntimeContext __runtime)
+#line hidden
         {{
 #line (1, 4) - (1, 12) ""TEST""
             {Runtime.RuntimeVariable}.SetVariable(""@foo"", null);
+#line hidden
         }}
     }}
 }}");

--- a/src/Sage.Engine/CommandLine/CommandLineExtensions.cs
+++ b/src/Sage.Engine/CommandLine/CommandLineExtensions.cs
@@ -53,6 +53,7 @@ namespace Sage.Engine
                     appServices.Configure<CompilationOptions>((o) =>
                     {
                         o.InputFile = ampscriptOption.Source;
+                        o.GeneratedMethodName = CompilerOptionsBuilder.BuildMethodFromFilename(ampscriptOption.Source.FullName);
                     });
                 });
 

--- a/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
+++ b/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
@@ -201,7 +201,7 @@ internal class CSharpTranspiler
                                 .WithType(
                                     IdentifierName("RuntimeContext")))))
             .WithBody(
-                Block(statements))
+                TranspilerExtensions.BlockWithHiddenDirectives(statements))
             .WithHiddenLineDirective();
     }
 }

--- a/src/Sage.Engine/Transpiler/IfVisitor.cs
+++ b/src/Sage.Engine/Transpiler/IfVisitor.cs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using Microsoft.CodeAnalysis.CSharp;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Sage.Engine.Parser;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -23,17 +26,19 @@ internal class IfVisitor : SageParserBaseVisitor<IfStatementSyntax>
 
     private IfStatementSyntax GetIf(ExpressionSyntax expression, IEnumerable<StatementSyntax> block)
     {
-        return IfStatement(expression, Block(block));
+        return IfStatement(
+            expression,
+            TranspilerExtensions.BlockWithHiddenDirectives(block));
     }
 
     public override IfStatementSyntax VisitIfStatement(SageParser.IfStatementContext context)
     {
         ExpressionSyntax e = _transpiler.ExpressionVisitor.Visit(context.expression());
-        return GetIf(e, _transpiler.BlockVisitor.Visit(context.contentBlock()));
+        return GetIf(e, _transpiler.BlockVisitor.Visit(context.contentBlock())).WithLineDirective(context.expression(), this._transpiler.SourceFileName);
     }
 
     public override IfStatementSyntax VisitElseIfStatement(SageParser.ElseIfStatementContext context)
     {
-        return GetIf(_transpiler.ExpressionVisitor.Visit(context.expression()), _transpiler.BlockVisitor.Visit(context.contentBlock()));
+        return GetIf(_transpiler.ExpressionVisitor.Visit(context.expression()), _transpiler.BlockVisitor.Visit(context.contentBlock())).WithLineDirective(context.expression(), this._transpiler.SourceFileName);
     }
 }

--- a/src/Sage.Engine/Transpiler/TranspilerExtensions.cs
+++ b/src/Sage.Engine/Transpiler/TranspilerExtensions.cs
@@ -82,6 +82,21 @@ internal static class TranspilerExtensions
     }
 
     /// <summary>
+    /// Decorates the provided syntax node with a #line directive, indicating which line in the source file this represents.
+    /// </summary>
+    /// <see cref="https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/enhanced-line-directives.md"/>
+    public static BlockSyntax BlockWithHiddenDirectives(IEnumerable<StatementSyntax> statements)
+    {
+        return Block(statements)
+            .WithOpenBraceToken(Token(
+                TriviaList(Trivia(LineDirectiveTrivia(Token(SyntaxKind.HiddenKeyword), true))),
+                SyntaxKind.OpenBraceToken, TriviaList()))
+            .WithCloseBraceToken(Token(
+                TriviaList(Trivia(LineDirectiveTrivia(Token(SyntaxKind.HiddenKeyword), true))),
+                SyntaxKind.CloseBraceToken, TriviaList()));
+    }
+
+    /// <summary>
     /// Invokes a static method on a given class. Arguments can be added to the returned InvocationExpression
     /// </summary>
     /// <param name="className">Name of the class, without the namespace</param>


### PR DESCRIPTION
There were issues when stepping through code where you could hit F10 and walk into a line of AMPscript code that wasn't actually executing.  This was due to how blocks and their line directives were handled. This updates makes changes to ignore open braces for blocks for a better experience walking through AMPscript code.