### PR TITLE
Updated the installation instructions to mention that the .NET SDK is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AMPscript Core
+
 AMPscript Core is an open source implementation of the Marketing Cloud AMPscript language.
 
 It is cross platform and works on Windows, macOS and Linux.
@@ -8,15 +9,22 @@ A VSCode plugin is available to edit, run and debug AMPscript files locally on y
 <img src="docs/img/welcome.gif" alt="VSCode Plugin" width="50%"/>
 
 ## Getting Started Using the VSCode Plugin
+
 The VSCode plugin provides syntax highlighting and debugging capability for AMPscript files.
 The plugin supports files with a ".ampscript" extension.
 
 It is not yet available on the VSCode marketplace. In order use it, you will need to download and install the VSIX file that contains the plugin.
 
 #### Download and Install VSCode
-If you do not have VSCode installed, install it here: https://code.visualstudio.com/download
+
+If it isn't already installed on your computer, install Visual Studion Code (VS Code). You can download the latest version of VS Code from https://code.visualstudio.com/download.
+
+#### Download and Install the .NET SDK
+
+If it isn't already installed on your computer, install the .NET SDK version 7.0 or later. You can download the SDK from https://dotnet.microsoft.com/en-us/download/dotnet.
 
 #### Download the VSIX plugin
+
 Download the latest VSIX release from the [releases](https://github.com/SalesforceLabs/ampscript-core/releases) tab.
 
 Install the plugin using "Install From VSIX" in the extensions menu.
@@ -24,6 +32,7 @@ Install the plugin using "Install From VSIX" in the extensions menu.
 <img src="docs/img/install-vsix.png" alt="Install From VSIX" width="50%"/>
 
 #### Unzip the example
+
 Download the example ZIP from the [releases](https://github.com/SalesforceLabs/ampscript-core/releases) tab, and unzip this somewhere on your computer.
 
 Do File->Open Folder and choose the folder where this was unzipped.
@@ -31,11 +40,12 @@ Do File->Open Folder and choose the folder where this was unzipped.
 <img src="docs/img/open-folder.png" alt="Open Example Folder" width="50%"/>
 
 #### Start the example
+
 Double click on the "dd4tmp.ampscript" file, then go to the "Run and Debug" section of the editor and click "Run and Debug".
 
 <img src="docs/img/open-file.png" alt="Open Root File" width="40%"/> <img src="docs/img/run-and-debug.png" alt="Open Root File" width="40%"/>
 
-A browser window should appear with the example running.  From here - you can make any changes to the example and reload your browser window.
+A browser window should appear with the example running. From here - you can make any changes to the example and reload your browser window.
 
 <img src="docs/img/example-running.png" alt="Example Running" width="40%"/>
 
@@ -46,6 +56,7 @@ Subscriber attributes `%%Foo%%`/`[Foo]` are supported through a JSON file named 
 Supported within the JSON file is a key/value pair of the attribute name and value.
 
 Example:
+
 ```json
 {
     "FirstName": "Logan"
@@ -53,6 +64,7 @@ Example:
 ```
 
 The attribute values can be referenced via:
+
 ```ampscript
 %%[
     SET @FIRSTNAME = [FirstName]
@@ -64,54 +76,61 @@ Hello %%FirstName%%
 ```
 
 ## Referencing Content
-Content functions can reference content local on disk.  The files must exist in a `Content` subdirectory of the working directory.
+
+Content functions can reference content local on disk. The files must exist in a `Content` subdirectory of the working directory.
 
 Example, if you have a file at `Content\EmbeddedContent.ampscript`, then you can reference it via:
+
 ```ampscript
 %%=CONTENTBLOCKBYNAME("EmbeddedContent")=%%
 ```
 
 ## Data Extensions
-Data Extension support is provided through CSV files on disk.  The files must exist in a `DataExtensions` subdirectory of the working directory. The CSV file must contain headers which represent the columns.
+
+Data Extension support is provided through CSV files on disk. The files must exist in a `DataExtensions` subdirectory of the working directory. The CSV file must contain headers which represent the columns.
 
 Example, if you have a file at `DataExtensions\Loyalty.csv`, then it will use this CSV file as the data extension.
 
 `DataExtensions\Loyalty.csv`
+
 ```csv
 EmailAddress,SubscriberKey,FirstName,LastName,LoyaltyLevel
 donnie@northerntrailoutfitters.com,1,Donnie,Stanton,Silver
 ```
 
 `Index.ampscript`
+
 ```ampscript
 Hello %%=LOOKUP("Loyalty", "FirstName", "emailAddress", "donnie@northerntrailoutfitters.com")=%%
 ```
 
 Outputs:
+
 ```ampscript
 Hello Donnie
 ```
 
 ### ⚠️ AMPscript Support
-| Feature | Summary |
-|----------|---------|
-| Ampscript Blocks `%%[]%%` | ✔️ |
-| Variables | ✔️ |
-| For `for`| ✔️ |
-| If `if`| ✔️ |
-| Logic Operators `==`, `!=`, `&&`, etc | ✔️ |
-| Inline Ampscript `%%= =%%`| ✔️ |
-| Personalization Strings `[Foo]` or `%%Foo%%` | ✔️ |
-| Tag Syntax `<script language="ampscript">` | ✔️ |
+
+| Feature                                             | Summary              |
+| --------------------------------------------------- | -------------------- |
+| Ampscript Blocks `%%[]%%`                           | ✔️                   |
+| Variables                                           | ✔️                   |
+| For `for`                                           | ✔️                   |
+| If `if`                                             | ✔️                   |
+| Logic Operators `==`, `!=`, `&&`, etc               | ✔️                   |
+| Inline Ampscript `%%= =%%`                          | ✔️                   |
+| Personalization Strings `[Foo]` or `%%Foo%%`        | ✔️                   |
+| Tag Syntax `<script language="ampscript">`          | ✔️                   |
 | System Strings `xtmonth, jobid, subscriberkey, etc` | ⛔ Not Yet Supported |
 
 ## Marketing Cloud Supported Languages
 
-| Language | Summary |
-|----------|---------|
+| Language  | Summary            |
+| --------- | ------------------ |
 | AMPscript | ⚠️ Partial support |
-| SSJS | ⛔ Not supported |
-| GTL | ⛔ Not Supported |
+| SSJS      | ⛔ Not supported   |
+| GTL       | ⛔ Not Supported   |
 
 ## Supported Functions
 
@@ -135,12 +154,13 @@ If the function isn't listed here, then it's not supported.
 |[Utility](https://ampscript.guide/utility-functions/)| ⚠️ Partial Support |
 |[Content Syndication](https://ampscript.guide/content-syndication/)| ⛔ Not Supported |
 
-
 ## Roadmap
-* Increase supported feature
-* SSJS & GTL
-* Static code analysis tools to identify and remediate performance or security issues
+
+-   Increase supported feature
+-   SSJS & GTL
+-   Static code analysis tools to identify and remediate performance or security issues
 
 ## Docs
+
 -   [Code of Conduct](./CODE_OF_CONDUCT.md)
 -   [LICENSE](./LICENSE)


### PR DESCRIPTION
On macOS (and presumably Linux, not sure about Windows), the .NET SDK is required in order to start the server. VS Code automatically prompts you to install the SDK if it's not already installed, so it's not a huge problem if it isn't installed first. 