### PR TITLE
Create output directory if missing

### DIFF
--- a/src/Sage.Engine.Tests/Functions/ContentTests.cs
+++ b/src/Sage.Engine.Tests/Functions/ContentTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Sage.Engine.Runtime;
+
+namespace Sage.Engine.Tests.Functions
+{
+    [TestFixture]
+    internal class ContentTests : FunctionTestBase
+    {
+        [Test]
+        [TestCase("%%=ADD(1,2)=%%", "3")]
+        public void TestTreatAsContentNoOutputDirectory(string input, string expected)
+        {
+            var options = TestCompilationOptions();
+            options.OutputDirectory = new DirectoryInfo(Path.Combine(options.OutputDirectory.FullName, "doesnotexist"));
+            var context = new RuntimeContext(_serviceProvider, options);
+
+            string results = context.TREATASCONTENT(input);
+            Assert.That(results, Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/Sage.Engine/Compiler/CompilerOptionsBuilder.cs
+++ b/src/Sage.Engine/Compiler/CompilerOptionsBuilder.cs
@@ -62,6 +62,12 @@ namespace Sage.Engine.Compiler
         public CompilerOptionsBuilder WithSourceCode(string name, string sourceCode)
         {
             this.InputName = name;
+
+            if (!this.OutputDirectory.Exists)
+            {
+                this.OutputDirectory.Create();
+            }
+
             this.InputFile = new FileInfo(Path.Combine(this.OutputDirectory.FullName, name + ".generated.ampscript"));
             File.WriteAllText(InputFile.FullName, this.SourceCode);
             this.SourceCode = sourceCode;


### PR DESCRIPTION
This fixes issue #18 where TREATASCONTENT will fail if the output directory is missing.