### PR TITLE
Add additional AMPscript functions

### DIFF
--- a/src/Sage.Engine.Tests/Corpus/CorpusLoader.cs
+++ b/src/Sage.Engine.Tests/Corpus/CorpusLoader.cs
@@ -120,8 +120,8 @@ namespace Sage.Engine.Tests
 
                         testsFromFile.Add(new CorpusData(testName, code.ToString().Trim(), file, lineStart)
                         {
-                            Output = expectedOutput,
-                            ParseTree = parseTree.ToString().Trim()
+                            Output = expectedOutput.ReplaceLineEndings("\n"),
+                            ParseTree = parseTree.ToString().Trim().ReplaceLineEndings("\n")
                         });
 
                         parseTree = new StringBuilder();
@@ -182,8 +182,8 @@ namespace Sage.Engine.Tests
             expectedOutput = programOutput.ToString().Trim();
             testsFromFile.Add(new CorpusData(testName, code.ToString().Trim(), file, lineStart)
             {
-                Output = expectedOutput,
-                ParseTree = parseTree.ToString().Trim()
+                Output = expectedOutput.ReplaceLineEndings("\n"),
+                ParseTree = parseTree.ToString().Trim().ReplaceLineEndings("\n")
             });
 
             return testsFromFile;

--- a/src/Sage.Engine.Tests/Corpus/Function/http.txt
+++ b/src/Sage.Engine.Tests/Corpus/Function/http.txt
@@ -4,3 +4,42 @@ REDIRECTO
 %%=REDIRECTTO("http://example.com")=%%
 ++++++++++
 http://example.com
+==========
+URLENCODE("Hello World", false, false)
+==========
+%%=URLENCODE("Hello World")=%%
+++++++++++
+Hello World
+==========
+URLENCODE("Hello World", false, false)
+==========
+%%=URLENCODE("Hello World", 0, 1)=%%
+++++++++++
+Hello%20World
+==========
+URLENCODE Only Spaces As HTML
+==========
+%%=URLENCODE("http://example.com?query=Hello World,",false,false)=%%
+++++++++++
+http://example.com?query=Hello%20World,
+==========
+URLENCODE Spaces Plus And All Others
+==========
+%%=URLENCODE("http://example.com?query=Hello World,",true,false)=%%
+++++++++++
+http://example.com?query%3dHello+World%2c
+==========
+URLENCODE Unicode
+==========
+%%=URLEncode('Sample Text: サンプルテキスト', true, true)=%%
+++++++++++
+Sample+Text%3a+%e3%82%b5%e3%83%b3%e3%83%97%e3%83%ab%e3%83%86%e3%82%ad%e3%82%b9%e3%83%88
+==========
+URLENCODE AMPscript In URL
+==========
+%%[
+    SET @url = "http://example.com?add=%%=ADD(1,2)=%%"
+]%%
+%%=URLEncode(@url)=%%
+++++++++++
+http://example.com?add=3

--- a/src/Sage.Engine.Tests/Corpus/Function/strings.txt
+++ b/src/Sage.Engine.Tests/Corpus/Function/strings.txt
@@ -245,3 +245,46 @@ set @lowercase = "^[a-z]+$"
 abc
 
 ABC
+==========
+BUILDROWSETFROMSTRING
+==========
+%%[
+SET @STRING = "ONE|TWO|THREE|FOUR"
+SET @ROWS=BUILDROWSETFROMSTRING(@STRING, "|")
+SET @ROWCOUNT=ROWCOUNT(@ROWS)
+]%%
+%%=V(@ROWCOUNT)=%%
+%%=V(FIELD(ROW(@ROWS, 1), 1))=%%
+%%=V(FIELD(ROW(@ROWS, 2), 1))=%%
+%%=V(FIELD(ROW(@ROWS, 3), 1))=%%
+%%=V(FIELD(ROW(@ROWS, 4), 1))=%%
+++++++++++
+4
+ONE
+TWO
+THREE
+FOUR
+==========
+BUILDROWSETFROMSTRING bad row
+==========
+%%[
+SET @STRING = "ONE|TWO|THREE|FOUR"
+SET @ROWS=BUILDROWSETFROMSTRING(@STRING, "|")
+SET @ROWCOUNT=ROWCOUNT(@ROWS)
+]%%
+%%=V(@ROWCOUNT)=%%
+%%=V(FIELD(ROW(@ROWS, 5), 1))=%%
+++++++++++
+!
+==========
+BUILDROWSETFROMSTRING bad field
+==========
+%%[
+SET @STRING = "ONE|TWO|THREE|FOUR"
+SET @ROWS=BUILDROWSETFROMSTRING(@STRING, "|")
+SET @ROWCOUNT=ROWCOUNT(@ROWS)
+]%%
+%%=V(@ROWCOUNT)=%%
+%%=V(FIELD(ROW(@ROWS, 1), 2))=%%
+++++++++++
+!

--- a/src/Sage.Engine.Tests/Corpus/Function/utility.txt
+++ b/src/Sage.Engine.Tests/Corpus/Function/utility.txt
@@ -112,7 +112,7 @@ PASS
 ==========
 FORMATNUMBER Rounding
 ==========
-%%=FormatNumber(123.445,"N2")=%%
+%%=FormatNumber(123.4451,"N2")=%%
 ++++
 123.45
 ==========
@@ -130,7 +130,7 @@ FORMATNUMBER Normalizing Numbers
 ==========
 FORMATNUMBER Localizing Numbers 
 ==========
-%%=FormatNumber("123.445","C2","de_DE")=%%
+%%=FormatNumber("123.4451","C2","de_DE")=%%
 ++++
 123,45 €
 ==========

--- a/src/Sage.Engine.Tests/Corpus/Function/utility.txt
+++ b/src/Sage.Engine.Tests/Corpus/Function/utility.txt
@@ -50,3 +50,98 @@ set @num = 12345
 %%=Format(@num,"C", "Numeric")=%%
 ++++++++++
 $12,345.00
+==========
+GETSENDTIME matches NOW
+==========
+%%[
+SET @NOW1 = FORMAT(NOW(), "YYYY-MM-dd hh:mm")
+SET @SENDTIME = FORMAT(GETSENDTIME(), "YYYY-MM-dd hh:mm")
+SET @NOW2 = FORMAT(NOW(), "YYYY-MM-dd hh:mm")
+
+/* 
+This tests the time twice (now1 and now2) because if the test runs during a minute boundary, now1 may be :59 and SENDTIME might be :00.
+By doing it before & after, it'll guarantee to catch a minute rollover.
+*/
+
+
+IF (@NOW1 == @SENDTIME) THEN
+]%%
+PASS
+%%[
+ELSEIF (@SENDTIME == @NOW2) THEN
+]%%
+PASS
+%%[
+ELSE
+]%%
+FAIL
+%%[
+ENDIF
+]%%
+++++++++++
+PASS
+==========
+GETSENDTIME(TRUE) matches NOW
+==========
+%%[
+SET @NOW1 = FORMAT(NOW(), "YYYY-MM-dd hh:mm")
+SET @SENDTIME = FORMAT(GETSENDTIME(TRUE), "YYYY-MM-dd hh:mm")
+SET @NOW2 = FORMAT(NOW(), "YYYY-MM-dd hh:mm")
+
+/* 
+This tests the time twice (now1 and now2) because if the test runs during a minute boundary, now1 may be :59 and SENDTIME might be :00.
+By doing it before & after, it'll guarantee to catch a minute rollover.
+*/
+
+IF (@NOW1 == @SENDTIME) THEN
+]%%
+PASS
+%%[
+ELSEIF (@SENDTIME == @NOW2) THEN
+]%%
+PASS
+%%[
+ELSE
+]%%
+FAIL
+%%[
+ENDIF
+]%%
+++++++++++
+PASS
+==========
+FORMATNUMBER Rounding
+==========
+%%=FormatNumber(123.445,"N2")=%%
+++++
+123.45
+==========
+FORMATNUMBER Converting Strings to Numbers 
+==========
+%%=FormatNumber("1234.56", "N")=%%
+++++
+1,234.56
+==========
+FORMATNUMBER Normalizing Numbers 
+==========
+%%=FormatNumber("1,234.56","G","en_US")=%%
+++++
+1234.56
+==========
+FORMATNUMBER Localizing Numbers 
+==========
+%%=FormatNumber("123.445","C2","de_DE")=%%
+++++
+123,45 €
+==========
+FORMATNUMBER Converting Numbers to Percentages
+==========
+%%[
+  Set @val1 = 42
+  Set @val2 = 326
+  Set @pct = Divide(@val1, @val2)
+]%%
+
+%%=FormatNumber(@pct, "P3")=%%
+++++
+12.883%

--- a/src/Sage.Engine.Tests/Corpus/Incompatible/Compatibility.ampscript
+++ b/src/Sage.Engine.Tests/Corpus/Incompatible/Compatibility.ampscript
@@ -36,3 +36,24 @@ set @result = DATEPARSE("2023-05-01 2:30PM-1:00", 0)
 %%=v(@result)=%%
 ++++++++++
 5/1/2023 11:30:00 AM
+==========
+FORMATNUMBER Rounding
+==========
+%%[
+/*
+https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+
+Specifically:
+On .NET Framework and .NET Core up to .NET Core 2.0, the runtime selects the result with the greater least significant digit (that is, using MidpointRounding.AwayFromZero).
+On .NET Core 2.1 and later, the runtime selects the result with an even least significant digit (that is, using MidpointRounding.ToEven).
+
+The existing implementation is on .net framework, this is .net core 2.1.
+
+This means that rounding will be different for situations like below.
+
+The AMPscript implementation is 123.45, AMPscript Core is 123.44 due to this difference.
+*/
+]%%
+%%=FormatNumber(123.445,"N2")=%%
+++++
+123.44

--- a/src/Sage.Engine.Tests/EngineTestAttribute.cs
+++ b/src/Sage.Engine.Tests/EngineTestAttribute.cs
@@ -99,7 +99,7 @@ namespace Sage.Engine.Tests
 
         protected override object GetTestValidationData(CorpusData data)
         {
-            return new ParserTestResult(data.ParseTree);
+            return new ParserTestResult(data.ParseTree?.ReplaceLineEndings("\n") ?? string.Empty);
         }
     }
 
@@ -114,7 +114,7 @@ namespace Sage.Engine.Tests
 
         protected override object GetTestValidationData(CorpusData data)
         {
-            return new EngineTestResult(data.Output);
+            return new EngineTestResult(data.Output?.ReplaceLineEndings("\n") ?? string.Empty);
         }
     }
 }

--- a/src/Sage.Engine.Tests/Functions/FunctionTests.cs
+++ b/src/Sage.Engine.Tests/Functions/FunctionTests.cs
@@ -35,7 +35,7 @@ namespace Sage.Engine.Tests.Functions
             else
             {
                 RenderResponse compatibilityResult = TestCompatibility(test.Code, test.SubscriberContext?.GetAttributes()).Result;
-                return new EngineTestResult(compatibilityResult.renderedContent?.Trim());
+                return new EngineTestResult(compatibilityResult.renderedContent?.Trim().ReplaceLineEndings("\n"));
             }
         }
     }

--- a/src/Sage.Engine.Tests/Functions/FunctionTests.cs
+++ b/src/Sage.Engine.Tests/Functions/FunctionTests.cs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using MarketingCloudIntegration.Render;
+
 namespace Sage.Engine.Tests.Functions
 {
     using NUnit.Framework;
@@ -23,23 +25,18 @@ namespace Sage.Engine.Tests.Functions
         [Category("Compatibility")]
         public EngineTestResult TestFunctionsFromScriptCodeCompatibility(CorpusData test)
         {
-            var result = TestUtils.GetOutputFromTest(_serviceProvider, test);
-            Assert.That(result.Output, Is.EqualTo(test.Output));
-
             if (test.Output == "!")
             {
                 Assert.Throws<AggregateException>(() =>
                     TestCompatibility(test.Code, test.SubscriberContext?.GetAttributes()).Wait()
                 );
+                return new EngineTestResult("!");
             }
             else
             {
-                var compatibilityResult = TestCompatibility(test.Code, test.SubscriberContext?.GetAttributes()).Result;
-
-                Assert.That(compatibilityResult.renderedContent?.Trim().ReplaceLineEndings("\n"), Is.EqualTo(test.Output?.ReplaceLineEndings("\n")));
+                RenderResponse compatibilityResult = TestCompatibility(test.Code, test.SubscriberContext?.GetAttributes()).Result;
+                return new EngineTestResult(compatibilityResult.renderedContent?.Trim());
             }
-
-            return result;
         }
     }
 }

--- a/src/Sage.Engine.Tests/TestUtils.cs
+++ b/src/Sage.Engine.Tests/TestUtils.cs
@@ -22,7 +22,7 @@ public static class TestUtils
         ParserTestResult result;
 
         IParseTree parseTree = AntlrParser.Parse(test.Code, Console.Out, Console.Error);
-        string serializedTree = AntlrParser.SerializeTree(parseTree);
+        string serializedTree = AntlrParser.SerializeTree(parseTree).ReplaceLineEndings("\n");
         result = new ParserTestResult(serializedTree);
 
         File.WriteAllText(Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{test.FileFriendlyName}_expected.txt"),
@@ -52,7 +52,7 @@ public static class TestUtils
 
         try
         {
-            var engineResult = new EngineTestResult(CSharpCompiler.CompileAndExecute(options, GetTestRuntimeContext(serviceProvider, options, test), out CompileResult compileResult).Trim());
+            var engineResult = new EngineTestResult(CSharpCompiler.CompileAndExecute(options, GetTestRuntimeContext(serviceProvider, options, test), out CompileResult compileResult).ReplaceLineEndings("\n").Trim());
 
             File.WriteAllText(Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{test.FileFriendlyName}_transpiled.cs"), compileResult.TranspiledSource);
 

--- a/src/Sage.Engine/Globalization/CompatibleGlobalizationSettings.cs
+++ b/src/Sage.Engine/Globalization/CompatibleGlobalizationSettings.cs
@@ -10,22 +10,61 @@ namespace Sage.Engine.Runtime
     public static class CompatibleGlobalizationSettings
     {
         /// <summary>
+        /// AMPscript supports both "en-us" AND "en_us".  In order to quickly support this lookup, a dictionary of names->cultures is made and populated
+        /// on demand.
+        /// </summary>
+        private static readonly Lazy<Dictionary<string, CultureInfo>> s_cultureLookup = new(CacheCultureNameLookup, LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>
+        /// Caches a lookup of name->culture, along with any modifications that are needed to be compatible with the existing language.
+        ///
+        /// This cache is populated at first access.
+        /// </summary>
+        private static Dictionary<string, CultureInfo> CacheCultureNameLookup()
+        {
+            CultureInfo[] validCultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+            var returnDictionary = new Dictionary<string, CultureInfo>(validCultures.Length, StringComparer.InvariantCultureIgnoreCase);
+            foreach (CultureInfo culture in validCultures)
+            {
+                CultureInfo usedCulture = GenerateCompatibleCulture(culture);
+                returnDictionary[usedCulture.Name] = usedCulture;
+
+                if (usedCulture.Name.IndexOf("-", StringComparison.Ordinal) > 0)
+                {
+                    returnDictionary[usedCulture.Name.Replace("-", "_")] = usedCulture;
+                }
+            }
+
+            return returnDictionary;
+        }
+
+        /// <summary>
         /// There will be many differences between linux, mac, windows for globalization settings.
         /// Example, see: https://github.com/dotnet/runtime/issues/18345
         /// In that issue, there is no desire to support common settings between different OSs.
         /// In order to maintain compatibility with existing code, the culture infos are hardcoded.
-        /// For now, just support en-US.  In the future, a more robust test stratgy and validation needs created.
+        /// For now, just support en-US.  In the future, a more robust test strategy and validation needs created.
+        /// </summary>
+        private static CultureInfo GenerateCompatibleCulture(CultureInfo culture)
+        {
+            if (culture.Name.ToLower() == "en-us")
+            {
+                var returnCulture = (CultureInfo)culture.Clone();
+                returnCulture.DateTimeFormat.ShortDatePattern = "M/d/yyyy";
+                returnCulture.NumberFormat.NumberDecimalDigits = 2;
+
+                return returnCulture;
+            }
+
+            return culture;
+        }
+
+        /// <summary>
+        /// Obtains the compatible CultureInfo from the given culture name
         /// </summary>
         public static CultureInfo GetCulture(string culture)
         {
-            CultureInfo returnCulture = (CultureInfo)(new CultureInfo(culture, false)).Clone();
-
-            if (culture.ToLower() == "en-us")
-            {
-                returnCulture.DateTimeFormat.ShortDatePattern = "M/d/yyyy";
-            }
-
-            return returnCulture;
+            return s_cultureLookup.Value[culture];
         }
     }
 }

--- a/src/Sage.Engine/Runtime/Functions/Content.cs
+++ b/src/Sage.Engine/Runtime/Functions/Content.cs
@@ -73,7 +73,7 @@ namespace Sage.Engine.Runtime
             string id = this.ThrowIfStringNullOrEmpty(contentAreaId);
 
             string? executionResults =
-                CompileAndExecuteEmbeddedCodeAsync($"contentareaid__{id}",
+                CompileAndExecuteEmbeddedCode($"contentareaid__{id}",
                     () => GetClassicContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id)));
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
@@ -94,7 +94,7 @@ namespace Sage.Engine.Runtime
             string id = this.ThrowIfStringNullOrEmpty(contentAreaName);
 
             string? executionResults =
-                CompileAndExecuteEmbeddedCodeAsync($"contentareaname__{id}",
+                CompileAndExecuteEmbeddedCode($"contentareaname__{id}",
                     () => GetClassicContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id)));
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
@@ -115,7 +115,7 @@ namespace Sage.Engine.Runtime
             string id = this.ThrowIfStringNullOrEmpty(contentBlockName);
 
             string? executionResults =
-                CompileAndExecuteEmbeddedCodeAsync($"contentblockname__{id}",
+                CompileAndExecuteEmbeddedCode($"contentblockname__{id}",
                     () => GetContentBuilderContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id)));
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
@@ -136,7 +136,7 @@ namespace Sage.Engine.Runtime
             string id = this.ThrowIfStringNullOrEmpty(contentBlockId);
 
             string? executionResults =
-                CompileAndExecuteEmbeddedCodeAsync($"contentblockid__{id}",
+                CompileAndExecuteEmbeddedCode($"contentblockid__{id}",
                     () => GetContentBuilderContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id)));
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
@@ -157,7 +157,7 @@ namespace Sage.Engine.Runtime
             string id = this.ThrowIfStringNullOrEmpty(contentBlockKey);
 
             string? executionResults =
-                CompileAndExecuteEmbeddedCodeAsync($"contentblockkey__{id}",
+                CompileAndExecuteEmbeddedCode($"contentblockkey__{id}",
                     () => GetContentBuilderContentClient().GetContentByCustomerKey(this.ThrowIfStringNullOrEmpty(id)));
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
@@ -177,7 +177,7 @@ namespace Sage.Engine.Runtime
                 return contentString;
             }
 
-            return CompileAndExecuteEmbeddedCodeAsync($"treatascontent__{_stackFrame.Peek().CurrentLineNumber}", contentString) ?? string.Empty;
+            return CompileAndExecuteEmbeddedCode($"treatascontent", contentString) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/Sage.Engine/Runtime/Functions/Data.cs
+++ b/src/Sage.Engine/Runtime/Functions/Data.cs
@@ -166,7 +166,7 @@ namespace Sage.Engine.Runtime
 
             if (SageValue.TryToInt(index, out int intResult) != SageValue.UnboxResult.Fail)
             {
-                if (intResult > dataRow.Table?.Columns?.Count)
+                if (intResult <= dataRow.Table?.Columns?.Count)
                 {
                     returnResult = dataRow[intResult - 1];
                 }
@@ -178,7 +178,7 @@ namespace Sage.Engine.Runtime
 
             if (returnResult == null && SageValue.ToBoolean(missingIsFailure))
             {
-                throw new RuntimeException("Invalid attribute name passed to the FIELD function.  No attribute exists.", this);
+                throw new RuntimeException($"Invalid attribute passed to the FIELD function.  No attribute exists at index {index}", this);
             }
 
             return returnResult ?? string.Empty;

--- a/src/Sage.Engine/Runtime/Functions/DateTime.cs
+++ b/src/Sage.Engine/Runtime/Functions/DateTime.cs
@@ -19,11 +19,6 @@ namespace Sage.Engine.Runtime
         /// </param>
         public DateTimeOffset NOW(object? useSendTimeStarted = null)
         {
-            if (useSendTimeStarted != null)
-            {
-                throw new NotImplementedException("useSendTimeStarted is not implemented");
-            }
-
             // TODO: Use CST without daylight savings
             return DateTimeOffset.Now;
         }

--- a/src/Sage.Engine/Runtime/Functions/Http.cs
+++ b/src/Sage.Engine/Runtime/Functions/Http.cs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using System.Web;
+
 namespace Sage.Engine.Runtime
 {
     public partial class RuntimeContext
@@ -14,6 +16,83 @@ namespace Sage.Engine.Runtime
         public string REDIRECTTO(object? url)
         {
             return url?.ToString() ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Modifies a string to only include characters that are safe to use in URLs.
+        /// </summary>
+        /// <param name="encodeAllStrings">The string to convert to a format that is safe to include in URLs.</param>
+        /// <param name="encodeAllCharacters">
+        /// If true, the function converts all spaces and non-ASCII characters in a URL parameter string to their hexadecimal character codes.
+        ///
+        /// If false, the function only converts spaces in a URL parameter string to the hexadecimal character code %20, and leaves other characters unchanged.
+        ///
+        /// The default value is false.</param>
+        /// <param name="encodeAllStrings">
+        /// If true, the function converts any text string that you pass as the first parameter into a version that is safe to use in URLs.
+        ///
+        /// If false, the function only converts a string into a URL-safe version if the unsafe characters are part of a URL parameter string.
+        ///
+        /// The default value is false.</param>
+        public string URLENCODE(object urlToEncode, object? encodeAllCharacters = null, object? encodeAllStrings = null)
+        {
+            bool boolEncodeAllCharacters = false;
+
+            string urlString = urlToEncode?.ToString() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(urlString))
+            {
+                return urlString;
+            }
+
+            if (encodeAllCharacters != null)
+            {
+                boolEncodeAllCharacters = SageValue.ToBoolean(encodeAllCharacters);
+            }
+
+            bool boolEncodeAllStrings = false;
+            if (encodeAllStrings != null)
+            {
+                boolEncodeAllStrings = SageValue.ToBoolean(encodeAllStrings);
+            }
+
+            string renderedUrlResults = CompileAndExecuteEmbeddedCode("urlencode", urlString) ?? string.Empty;
+
+            string prefixPart = string.Empty;
+            string partToEncode = string.Empty;
+
+            if (boolEncodeAllStrings)
+            {
+                // No prefix, encoding all strings
+                partToEncode = renderedUrlResults;
+            }
+            else
+            {
+                int queryStringStart = renderedUrlResults.IndexOf('?');
+
+                if (queryStringStart > 0)
+                {
+                    prefixPart = renderedUrlResults.Substring(0, queryStringStart + 1);
+                    partToEncode = renderedUrlResults.Substring(queryStringStart + 1);
+                }
+                else
+                {
+                    prefixPart = renderedUrlResults;
+                    // No part to encode, no query string
+                }
+            }
+
+            string encodedString = null;
+
+            if (boolEncodeAllCharacters)
+            {
+                encodedString = HttpUtility.UrlEncode(partToEncode);
+            }
+            else
+            {
+                encodedString = partToEncode.Replace(" ", "%20");
+            }
+
+            return prefixPart + encodedString;
         }
     }
 }

--- a/src/Sage.Engine/Runtime/Functions/String.cs
+++ b/src/Sage.Engine/Runtime/Functions/String.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using System.Data;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -278,6 +279,35 @@ namespace Sage.Engine.Runtime
             string[] searchStrings = searches.Select(r => r?.ToString() ?? string.Empty).ToArray();
 
             return ReplaceWithCaseInsensitiveSearch(subjectString, replaceString, searchStrings);
+        }
+
+        /// <summary>
+        /// Creates a rowset from a character string by splitting the string at the specified delimiter.
+        /// </summary>
+        /// <param name="sourceData">A string that contains the data to load into a rowset.</param>
+        /// <param name="delimiter">The character (such as a comma) that is used as a delimiter in the source data.</param>
+        /// <remarks>The FIELD must always be accessed from the "1" index.</remarks>
+        /// <returns>A datatable representing the rowset to be used by ROWCOUNT, ROW and FIELD functions.</returns>
+        public DataTable BUILDROWSETFROMSTRING(object? sourceData, object? delimiter)
+        {
+            string sourceDataString = sourceData?.ToString() ?? string.Empty;
+            string delimiterString = delimiter?.ToString() ?? string.Empty;
+
+            var dataTable = new DataTable();
+            dataTable.Columns.Add(new DataColumn("Value", typeof(string)));
+
+            if (!string.IsNullOrEmpty(sourceDataString))
+            {
+                // Just split the string and add a row to the data table for each of the resulting strings
+                string[] split = sourceDataString.Split(delimiterString, StringSplitOptions.None);
+                foreach (string str in split)
+                {
+                    dataTable.Rows.Add(new object[] { str });
+                }
+                dataTable.AcceptChanges();
+            }
+
+            return dataTable;
         }
 
         /// <summary>

--- a/src/Sage.Engine/Runtime/Functions/Utility.cs
+++ b/src/Sage.Engine/Runtime/Functions/Utility.cs
@@ -36,7 +36,7 @@ namespace Sage.Engine.Runtime
                 string? cultureString = culture.ToString();
                 if (cultureString != null)
                 {
-                    cultureInfo = new CultureInfo(cultureString);
+                    cultureInfo = CompatibleGlobalizationSettings.GetCulture(cultureString);
                 }
             }
 
@@ -62,6 +62,40 @@ namespace Sage.Engine.Runtime
             {
                 return subject.ToString() ?? string.Empty;
             }
+        }
+
+        /// <summary>
+        /// Formats a number as a numeric type, such as a decimal, date, or currency value.
+        /// 
+        /// You can also use this function to convert numbers stored in strings to a number data type, and to round numbers to a certain number of decimal places.
+        /// </summary>
+        /// <param name="number">The number that you want to format. This function assumes that the input number uses a period (.) as a decimal separator.</param>
+        /// <param name="formatType">
+        /// The number type to convert the number to. Accepted values:
+        /// 
+        /// C - Formats the number as a currency value.
+        /// D - Formats the number as a decimal number.
+        /// E - Formats the number using scientific notation.
+        /// F - Formats the number to a fixed number of decimal places (two decimal places by default).
+        /// G - Formats the number without thousands separators.
+        /// N - Formats the number with thousands separators.
+        /// P - Formats the number as a percentage.
+        /// R - Round-trip (format ensures value parsed to string can be parsed back to numeric value)
+        /// X - Formats the number as a hexadecimal value.
+        /// You can optionally follow this code with a number to indicate the precision of the number. For example, a currency value with two decimal places uses the parameter C2.
+        /// </param>
+        /// <param name="culutreCode">A POSIX locale code, such as en_US or zh-TW. When you provide this value, the resulting number is formatted using patterns that suit the specified locale.</param>
+        public string FORMATNUMBER(object? number, object? formatType, object? culutreCode = null)
+        {
+            if (SageValue.TryToDouble(number, out double numberDouble) == SageValue.UnboxResult.Fail)
+            {
+                return string.Empty;
+            }
+
+            string formatTypeString = this.ThrowIfStringNullOrEmpty(formatType);
+            CultureInfo cultureInfo = CompatibleGlobalizationSettings.GetCulture(culutreCode?.ToString() ?? "en_US");
+
+            return numberDouble.ToString(formatTypeString, cultureInfo);
         }
 
         /// <summary>
@@ -131,6 +165,17 @@ namespace Sage.Engine.Runtime
             string attributeNameString = this.ThrowIfStringNullOrEmpty(attributeName);
 
             return GetSubscriberContext().GetAttribute(attributeNameString);
+        }
+
+        /// <summary>
+        /// Returns a timestamp for the beginning or end of a list, data extension (DE), or manual send at the job or individual subscriber level.
+        ///
+        /// For now, this only returns NOW() since there is no send that's part of this context.
+        /// </summary>
+        /// <param name="useSendTimeStarted">Ignored</param>
+        public DateTimeOffset GETSENDTIME(object? useSendTimeStarted = null)
+        {
+            return NOW(useSendTimeStarted);
         }
     }
 }

--- a/src/Sage.Engine/Runtime/RuntimeContext.cs
+++ b/src/Sage.Engine/Runtime/RuntimeContext.cs
@@ -203,12 +203,13 @@ namespace Sage.Engine.Runtime
             return _subscriberContext;
         }
 
-        internal string? CompileAndExecuteEmbeddedCodeAsync(string id, string code)
+        internal string? CompileAndExecuteEmbeddedCode(string id, string code)
         {
+            id = $"{_stackFrame.Peek().Name}__{id}__{_stackFrame.Peek().CurrentLineNumber}";
             CompilerOptionsBuilder fromCodeString =
                 new CompilerOptionsBuilder(_rootCompilationOptions).WithSourceCode(id, code);
 
-            return CompileAndExecuteEmbeddedCodeAsync(fromCodeString.Build(), code);
+            return CompileAndExecuteEmbeddedCode(fromCodeString.Build(), code);
         }
 
         /// <summary>
@@ -223,7 +224,7 @@ namespace Sage.Engine.Runtime
         /// of content retrieval.
         /// </param>
         /// <returns>The result of executing the code</returns>
-        internal string? CompileAndExecuteEmbeddedCodeAsync(string id, Func<FileInfo?> getCode)
+        internal string? CompileAndExecuteEmbeddedCode(string id, Func<FileInfo?> getCode)
         {
             FileInfo? code = getCode();
             if (code == null)
@@ -234,10 +235,10 @@ namespace Sage.Engine.Runtime
             CompilerOptionsBuilder fromFileOptions =
                 new CompilerOptionsBuilder(_rootCompilationOptions).WithInputFile(code);
 
-            return CompileAndExecuteEmbeddedCodeAsync(fromFileOptions.Build(), code);
+            return CompileAndExecuteEmbeddedCode(fromFileOptions.Build(), code);
         }
 
-        internal string? CompileAndExecuteEmbeddedCodeAsync(CompilationOptions currentOptions, object fileInfoOrString)
+        internal string? CompileAndExecuteEmbeddedCode(CompilationOptions currentOptions, object fileInfoOrString)
         {
             CompileResult compileResult = CSharpCompiler.GenerateAssemblyFromSource(currentOptions);
 


### PR DESCRIPTION
Adds the following functions:
URLENCODE - Modifies a string to only include characters that are safe to use in URLs.

BUILDROWSETFROMSTRING - Creates a rowset from a character string by splitting the string at the specified delimiter.

FORMATNUMBER - Formats a number as a numeric type, such as a decimal, date, or currency value.

There is a known issue with FORMATNUMBER for rounding digits.

Specifically:
https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings

On .NET Framework and .NET Core up to .NET Core 2.0, the runtime selects the result with the greater least significant digit (that is, using MidpointRounding.AwayFromZero). On .NET Core 2.1 and later, the runtime selects the result with an even least significant digit (that is, using MidpointRounding.ToEven).

The in-production AMPscript implementation is on .net framework, this is .net 8.