### PR TITLE
Create IContent interface for content compilation

### DIFF
--- a/src/Sage.Engine.Tests/CompilerTests.cs
+++ b/src/Sage.Engine.Tests/CompilerTests.cs
@@ -1,8 +1,9 @@
-// Copyright (c) 2022, salesforce.com, inc.
+﻿// Copyright (c) 2022, salesforce.com, inc.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
+using Microsoft.Extensions.DependencyInjection;
 using Sage.Engine.Runtime;
 
 namespace Sage.Engine.Tests
@@ -22,7 +23,7 @@ namespace Sage.Engine.Tests
             string pathToTest = Path.Combine(TestContext.CurrentContext.TestDirectory, "Corpus", "Compiler", sourceFile);
 
             Compiler.CompilationOptions options = new CompilerOptionsBuilder()
-                .WithInputFile(new FileInfo(pathToTest))
+                .WithContent(new LocalFileContent(pathToTest, 1))
                 .Build();
 
             CompileResult result = CSharpCompiler.GenerateAssemblyFromSource(options);
@@ -41,6 +42,19 @@ namespace Sage.Engine.Tests
                 ?.GetMethod(options.GeneratedMethodName)
                 ?.Invoke(null, variables);
             Assert.That(context.PopContext(), Is.EqualTo("Hello  World"));
+        }
+
+        [Test]
+        [TestCase("%%=ADD(1,2)=%%", ContentType.AMPscript, "3")]
+        public void TestRenderer(string input, ContentType type, string expected)
+        {
+            var content = new EmbeddedContent(input, "TEST", "TEST", 1, type);
+            CompilationOptions options = new CompilerOptionsBuilder()
+                .WithContent(content)
+                .Build();
+            var result = _serviceProvider.GetRequiredService<Renderer>().Render(options);
+
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/src/Sage.Engine.Tests/SageTest.cs
+++ b/src/Sage.Engine.Tests/SageTest.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Sage.Engine.Compiler;
 using Sage.Engine.DependencyInjection;
 using Sage.Engine.Extensions;
 using Sage.Engine.Tests.Compatibility;
@@ -51,8 +52,7 @@ namespace Sage.Engine.Tests
         {
             return new CompilationOptions()
             {
-                InputFile = new FileInfo("TEST.ampscript"),
-                InputName = "TEST",
+                Content = new EmbeddedContent("TEST", "TEST", "TEST.ampscript", 1, ContentType.AMPscript),
                 SymbolStream = new MemoryStream(),
                 AssemblyStream = new MemoryStream(),
                 OptimizationLevel = OptimizationLevel.Debug,

--- a/src/Sage.Engine.Tests/TestUtils.cs
+++ b/src/Sage.Engine.Tests/TestUtils.cs
@@ -40,6 +40,7 @@ public static class TestUtils
             options,
             test.SubscriberContext);
     }
+    
 
     /// <summary>
     /// Executes the engine and gets the expected result from the engine
@@ -47,7 +48,7 @@ public static class TestUtils
     public static EngineTestResult GetOutputFromTest(IServiceProvider serviceProvider, CorpusData test)
     {
         CompilationOptions options = new CompilerOptionsBuilder()
-            .WithSourceCode(test.FileFriendlyName, test.Code)
+            .WithContent(new EmbeddedContent(test.Code, test.FileFriendlyName, test.FileFriendlyName, 1, ContentType.AMPscript))
         .Build();
 
         try

--- a/src/Sage.Engine/CommandLine/CommandLineExtensions.cs
+++ b/src/Sage.Engine/CommandLine/CommandLineExtensions.cs
@@ -3,23 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.NamingConventionBinder;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Antlr4.Runtime.Misc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Sage.Engine.CommandLine;
 using Sage.Engine.Compiler;
 using Sage.Engine.Extensions;
-using static Sage.Engine.AmpscriptCommand;
 
 namespace Sage.Engine
 {
@@ -52,7 +41,7 @@ namespace Sage.Engine
 
                     appServices.Configure<CompilationOptions>((o) =>
                     {
-                        o.InputFile = ampscriptOption.Source;
+                        o.Content = new LocalFileContent(ampscriptOption.Source.FullName, 1);
                         o.GeneratedMethodName = CompilerOptionsBuilder.BuildMethodFromFilename(ampscriptOption.Source.FullName);
                     });
                 });

--- a/src/Sage.Engine/Compiler/AmpscriptCompiler.cs
+++ b/src/Sage.Engine/Compiler/AmpscriptCompiler.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Sage.Engine.Runtime;
+
+namespace Sage.Engine.Compiler
+{
+    /// <summary>
+    /// A class that compiles AMPscript source code into C# and optionally will execute it.
+    /// </summary>
+    internal class AmpscriptCompiler : IAmpscriptCompiler
+    {
+        public bool CanCompile(IContent content)
+        {
+            return content.ContentType == ContentType.AMPscript;
+        }
+
+        public string Compile(CompilationOptions options, RuntimeContext runtimeContext, SubscriberContext context)
+        {
+            return CSharpCompiler.CompileAndExecute(options, runtimeContext, out var _);
+        }
+    }
+}

--- a/src/Sage.Engine/Compiler/CompilationOptions.cs
+++ b/src/Sage.Engine/Compiler/CompilationOptions.cs
@@ -10,19 +10,15 @@ namespace Sage.Engine.Compiler
     /// <summary>
     /// Options specifying how the AMPscript code compiler should operate
     /// </summary>
-    /// <param name="InputName">Name of the input, usually the file name of the file</param>
-    /// <param name="InputFile">Path to the input ampscript file. Can be relative to the current working directory or absolute.</param>
-    /// <param name="SourceCode">The AMPscript source code</param>
-    /// <param name="SourceCode">The name of the generated method in the assembly</param>
+    /// <param name="Content">The AMPscript source code</param>
+    /// <param name="GeneratedMethodName">The name of the generated method in the assembly</param>
     /// <param name="OptimizationLevel">Optimization level of the generated code</param>
     /// <param name="OutputDirectory">What directory to output generated files</param>
     /// <param name="AssemblyStream">Stream for the assembly to be generated into</param>
     /// <param name="SymbolStream">Stream for the symbol file to be generated into</param>
     public class CompilationOptions
     {
-        public required string InputName { get; set; }
-        public required FileInfo InputFile { get; set; }
-        public string? SourceCode { get; set; }
+        public required IContent Content { get; set; }
         public required string GeneratedMethodName { get; set; }
         public required OptimizationLevel OptimizationLevel { get; set; }
         public required DirectoryInfo OutputDirectory { get; set; }

--- a/src/Sage.Engine/Compiler/CompilerOptionsBuilder.cs
+++ b/src/Sage.Engine/Compiler/CompilerOptionsBuilder.cs
@@ -30,47 +30,16 @@ namespace Sage.Engine.Compiler
         }
 
         /// <summary>
-        /// Name of the input, usually the file name of the file
-        /// </summary>
-        public string? InputName { get; private set; }
-
-        /// <summary>
         /// Path to the input ampscript file. Can be relative to the current working directory or absolute.
         /// </summary>
-        public FileInfo? InputFile { get; private set; }
-
-        /// <summary>
-        /// The AMPscript source code
-        /// </summary>
-        public string? SourceCode { get; private set; }
+        public IContent Content { get; private set; }
 
         /// <summary>
         /// Use the provided source file to compile code. This is not compatible with WithSourceCode.
         /// </summary>
-        public CompilerOptionsBuilder WithInputFile(FileInfo inputFile)
+        public CompilerOptionsBuilder WithContent(IContent content)
         {
-            this.InputFile = inputFile;
-            this.SourceCode = File.ReadAllText(inputFile.FullName);
-            this.InputName = inputFile.Name;
-
-            return this;
-        }
-
-        /// <summary>
-        /// This is dynamically generated code to compile that did not come from a file on disk.
-        /// </summary>
-        public CompilerOptionsBuilder WithSourceCode(string name, string sourceCode)
-        {
-            this.InputName = name;
-
-            if (!this.OutputDirectory.Exists)
-            {
-                this.OutputDirectory.Create();
-            }
-
-            this.InputFile = new FileInfo(Path.Combine(this.OutputDirectory.FullName, name + ".generated.ampscript"));
-            File.WriteAllText(InputFile.FullName, this.SourceCode);
-            this.SourceCode = sourceCode;
+            Content = content;
 
             return this;
         }
@@ -157,18 +126,16 @@ namespace Sage.Engine.Compiler
         /// </summary>
         public CompilationOptions Build()
         {
-            if (this.InputName == null || this.InputFile == null || this.SourceCode == null)
+            if (this.Content == null)
             {
-                throw new InvalidOperationException("No input has been specified");
+                throw new InvalidOperationException("No content has been specified");
             }
 
-            string generatedMethodName = BuildMethodFromFilename(this.InputName);
+            string generatedMethodName = BuildMethodFromFilename(Content.Name);
 
             return new CompilationOptions()
             {
-                InputName = this.InputName,
-                InputFile = this.InputFile,
-                SourceCode = this.SourceCode,
+                Content = Content,
                 GeneratedMethodName = generatedMethodName.ToString(),
                 OptimizationLevel = this.OptimizationLevel,
                 OutputDirectory = this.OutputDirectory,

--- a/src/Sage.Engine/Compiler/IAmpscriptCompiler.cs
+++ b/src/Sage.Engine/Compiler/IAmpscriptCompiler.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2023, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Compiler
+{
+    /// <summary>
+    /// Renders a piece of AMPscript content to a string.
+    /// </summary>
+    public interface IAmpscriptCompiler : ICompiler
+    {
+    }
+}

--- a/src/Sage.Engine/Content/ContentExtensions.cs
+++ b/src/Sage.Engine/Content/ContentExtensions.cs
@@ -40,5 +40,13 @@ namespace Sage.Engine.Compiler
                 services.Configure(options);
             }
         }
+
+        /// <summary>
+        /// Infers the type of content based on the path of the file.
+        /// </summary>
+        public static ContentType InferContentTypeFromFilename(string path)
+        {
+            return ContentType.AMPscript;
+        }
     }
 }

--- a/src/Sage.Engine/Content/EmbeddedFileContent.cs
+++ b/src/Sage.Engine/Content/EmbeddedFileContent.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Compiler
+{
+    /// <summary>
+    /// Content that is contained within other content.
+    /// </summary>
+    /// <remarks>
+    /// Recursive rendering, such as TREATASCONTENT, enables referencing content within content. This is the representation of that.
+    /// </remarks>
+    public class EmbeddedContent : IContent
+    {
+        public string Name { get; private set; }
+
+        public string Location { get; }
+
+        public int ContentVersion { get; private set; }
+
+        public ContentType ContentType { get; }
+
+        private string _content;
+
+        public EmbeddedContent(string content, string name, string location, int contentVersion, ContentType type)
+        {
+            _content = content;
+            Name = name;
+            Location = location;
+            ContentVersion = contentVersion;
+            ContentType = type;
+        }
+
+        public TextReader? GetTextReader()
+        {
+            return new StringReader(_content);
+        }
+    }
+}

--- a/src/Sage.Engine/Content/IContent.cs
+++ b/src/Sage.Engine/Content/IContent.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2024, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Compiler
+{
+    /// <summary>
+    /// The type of content that is represented
+    /// </summary>
+    public enum ContentType
+    {
+        AMPscript
+    };
+
+    /// <summary>
+    /// Represents content that can be compiled by this project
+    /// </summary>
+    public interface IContent
+    {
+        /// <summary>
+        /// This is a human-readable name of the piece of content
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// This is a human-readable location where the file can be found.
+        /// It can be a filepath, URL, or any other identifier relevant to the type of content.
+        /// </summary>
+        public string Location { get; }
+
+        /// <summary>
+        /// Supports content versioning
+        /// </summary>
+        public int ContentVersion { get; }
+
+        /// <summary>
+        /// Type of content this represents
+        /// </summary>
+        public ContentType ContentType { get; }
+
+        /// <summary>
+        /// Obtains a reader from this content to be read and compiled
+        /// </summary>
+        /// <returns></returns>
+        public TextReader? GetTextReader();
+    }
+}

--- a/src/Sage.Engine/Content/IContentClient.cs
+++ b/src/Sage.Engine/Content/IContentClient.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) 2022, salesforce.com, inc.
+﻿// Copyright (c) 2024, salesforce.com, inc.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Sage.Engine.Compiler;
 
 namespace Sage.Engine.Content
 {
@@ -12,21 +14,21 @@ namespace Sage.Engine.Content
         /// </summary>
         /// <param name="name">Name of the content area to return, including the path within the my contents folder if necessary</param>
         /// <returns>A local cached file on disk that contains the content</returns>
-        FileInfo? GetContentByName(string name);
+        IContent? GetContentByName(string name);
 
         /// <summary>
         /// Obtains a piece of content by a given ID
         /// </summary>
         /// <param name="name">The ID of the specified content</param>
         /// <returns>A local cached file on disk that contains the content</returns>
-        FileInfo? GetContentById(string id);
+        IContent? GetContentById(string id);
 
         /// <summary>
         /// Obtains a piece of content by a given customer key
         /// </summary>
         /// <param name="name">The customer key of the specified content</param>
         /// <returns>A local cached file on disk that contains the content</returns>
-        FileInfo? GetContentByCustomerKey(string customerKey);
+        IContent? GetContentByCustomerKey(string customerKey);
     }
 
     public interface IClassicContentClient : IContentClient

--- a/src/Sage.Engine/Content/LocalDiskContentClient.cs
+++ b/src/Sage.Engine/Content/LocalDiskContentClient.cs
@@ -29,7 +29,7 @@ namespace Sage.Engine.Content
         /// <summary>
         /// Returns content from a file with the specified name
         /// </summary>
-        public FileInfo? GetContentByName(string name)
+        public IContent? GetContentByName(string name)
         {
             return GetContentFromPath(name);
         }
@@ -37,7 +37,7 @@ namespace Sage.Engine.Content
         /// <summary>
         /// Returns content from a file with the specified name
         /// </summary>
-        public FileInfo? GetContentById(string id)
+        public IContent? GetContentById(string id)
         {
             return GetContentFromPath(id);
         }
@@ -45,7 +45,7 @@ namespace Sage.Engine.Content
         /// <summary>
         /// Returns content from a file with the specified name
         /// </summary>
-        public FileInfo? GetContentByCustomerKey(string customerKey)
+        public IContent? GetContentByCustomerKey(string customerKey)
         {
             return GetContentFromPath(customerKey);
         }
@@ -53,16 +53,15 @@ namespace Sage.Engine.Content
         /// <summary>
         /// Returns content from a file with the specified name in the directory provided at the construction of this object.
         /// </summary>,
-        private FileInfo? GetContentFromPath(string path)
+        private IContent? GetContentFromPath(string id)
         {
-            string finalPath = Path.Combine(_options.InputDirectory.FullName, $"{path}.ampscript");
-
-            if (!File.Exists(finalPath))
+            string filePath = Path.Combine(_options.InputDirectory.FullName, $"{id}.ampscript");
+            if (File.Exists(filePath))
             {
-                return null;
+                return new LocalFileContent(id, filePath, 1, ContentType.AMPscript);
             }
 
-            return new FileInfo(finalPath);
+            return null;
         }
     }
 }

--- a/src/Sage.Engine/Content/LocalFileContent.cs
+++ b/src/Sage.Engine/Content/LocalFileContent.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2024, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Compiler
+{
+    /// <summary>
+    /// Represents a content that's local on disk
+    /// </summary>
+    public class LocalFileContent : IContent
+    {
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Full path to the file
+        /// </summary>
+        public string Location { get; private set; }
+
+        public int ContentVersion { get; private set; }
+
+        public ContentType ContentType { get; }
+
+        private string _fullPath;
+
+        /// <summary>
+        /// Reads from a local file on disk.
+        /// </summary>
+        public LocalFileContent(string fullPath, int contentVersion)
+        {
+            _fullPath = fullPath;
+            Name = Path.GetFileNameWithoutExtension(fullPath);
+            Location = fullPath;
+            ContentVersion = contentVersion;
+            ContentType = ContentExtensions.InferContentTypeFromFilename(fullPath);
+        }
+
+        /// <summary>
+        /// Reads from a local file on disk - with an alternative name representing the content.
+        /// </summary>
+        public LocalFileContent(string name, string fullPath, int contentVersion, ContentType contentType)
+        {
+            _fullPath = fullPath;
+            Name = name;
+            Location = _fullPath;
+            ContentVersion = contentVersion;
+            ContentType = contentType;
+        }
+
+        /// <summary>
+        /// Opens the file for read
+        /// </summary>
+        public TextReader? GetTextReader()
+        {
+            return new StreamReader(File.OpenRead(_fullPath));
+        }
+    }
+}

--- a/src/Sage.Engine/DependencyInjection/SageDependencyInjectionExtensions.cs
+++ b/src/Sage.Engine/DependencyInjection/SageDependencyInjectionExtensions.cs
@@ -60,6 +60,7 @@ namespace Sage.Engine.DependencyInjection
             });
             services.AddLocalDiskContentClient();
             services.AddScoped<Renderer>();
+            services.AddScoped<ICompiler, AmpscriptCompiler>();
         }
     }
 }

--- a/src/Sage.Engine/ICompiler.cs
+++ b/src/Sage.Engine/ICompiler.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2024, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using Sage.Engine.Compiler;
+using Sage.Engine.Runtime;
+
+namespace Sage.Engine
+{
+    /// <summary>
+    /// Renders a piece of content to a string.
+    /// </summary>
+    public interface ICompiler
+    {
+        bool CanCompile(IContent type);
+
+        string Compile(CompilationOptions options, RuntimeContext runtimeContext, SubscriberContext context);
+    }
+}

--- a/src/Sage.Engine/Renderer.cs
+++ b/src/Sage.Engine/Renderer.cs
@@ -14,11 +14,14 @@ namespace Sage.Engine
     public class Renderer
     {
         private readonly IServiceProvider _services;
+        private readonly IEnumerable<ICompiler> _compilers;
 
         public Renderer(
-            IServiceProvider services)
+            IServiceProvider services,
+            IEnumerable<ICompiler> compilers)
         {
             _services = services;
+            _compilers = compilers;
         }
 
         public string Render(
@@ -27,7 +30,15 @@ namespace Sage.Engine
         {
             var runtimeContext = new RuntimeContext(_services, compOptions, context);
 
-            return CSharpCompiler.CompileAndExecute(compOptions, runtimeContext, out var _);
+            foreach (var compiler in _compilers)
+            {
+                if (compiler.CanCompile(compOptions.Content))
+                {
+                    return compiler.Compile(compOptions, runtimeContext, context);
+                }
+            }
+
+            throw new InternalEngineException("Failed to compile any content");
         }
     }
 }

--- a/src/Sage.Engine/Runtime/Functions/Content.cs
+++ b/src/Sage.Engine/Runtime/Functions/Content.cs
@@ -4,6 +4,7 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
 using System.Runtime.CompilerServices;
+using Sage.Engine.Compiler;
 
 // Ignore the following in this file - mostly due to enabling this codebase to adhere to these rules but AMPscript code may not.
 // ReSharper disable CheckNamespace
@@ -72,9 +73,13 @@ namespace Sage.Engine.Runtime
         {
             string id = this.ThrowIfStringNullOrEmpty(contentAreaId);
 
-            string? executionResults =
-                CompileAndExecuteEmbeddedCode($"contentareaid__{id}",
-                    () => GetClassicContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id)));
+            IContent? content = GetClassicContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id));
+            if (content == null)
+            {
+                throw new RuntimeException($"Failed to find content {id}", this);
+            }
+
+            string? executionResults = CompileAndExecuteReferencedCode(content);
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
         }
@@ -93,9 +98,13 @@ namespace Sage.Engine.Runtime
         {
             string id = this.ThrowIfStringNullOrEmpty(contentAreaName);
 
-            string? executionResults =
-                CompileAndExecuteEmbeddedCode($"contentareaname__{id}",
-                    () => GetClassicContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id)));
+            IContent? content = GetClassicContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id));
+            if (content == null)
+            {
+                throw new RuntimeException($"Failed to find content {id}", this);
+            }
+
+            string? executionResults = CompileAndExecuteReferencedCode(content);
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
         }
@@ -114,9 +123,13 @@ namespace Sage.Engine.Runtime
         {
             string id = this.ThrowIfStringNullOrEmpty(contentBlockName);
 
-            string? executionResults =
-                CompileAndExecuteEmbeddedCode($"contentblockname__{id}",
-                    () => GetContentBuilderContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id)));
+            IContent? content = GetContentBuilderContentClient().GetContentByName(this.ThrowIfStringNullOrEmpty(id));
+
+            string? executionResults = null;
+            if (content != null)
+            {
+                executionResults = CompileAndExecuteReferencedCode(content);
+            }
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
         }
@@ -135,9 +148,13 @@ namespace Sage.Engine.Runtime
         {
             string id = this.ThrowIfStringNullOrEmpty(contentBlockId);
 
-            string? executionResults =
-                CompileAndExecuteEmbeddedCode($"contentblockid__{id}",
-                    () => GetContentBuilderContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id)));
+            IContent? content = GetContentBuilderContentClient().GetContentById(this.ThrowIfStringNullOrEmpty(id));
+            string? executionResults = null;
+            if (content != null)
+            {
+                executionResults = CompileAndExecuteReferencedCode(content);
+            }
+
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
         }
@@ -156,9 +173,14 @@ namespace Sage.Engine.Runtime
         {
             string id = this.ThrowIfStringNullOrEmpty(contentBlockKey);
 
-            string? executionResults =
-                CompileAndExecuteEmbeddedCode($"contentblockkey__{id}",
-                    () => GetContentBuilderContentClient().GetContentByCustomerKey(this.ThrowIfStringNullOrEmpty(id)));
+            IContent? content = GetContentBuilderContentClient()
+                .GetContentByCustomerKey(this.ThrowIfStringNullOrEmpty(id));
+
+            string? executionResults = null;
+            if (content != null)
+            {
+                executionResults = CompileAndExecuteReferencedCode(content);
+            }
 
             return ReturnContentBasedOnInput(executionResults, id, throwIfNotFound, defaultContent, success);
         }
@@ -177,7 +199,7 @@ namespace Sage.Engine.Runtime
                 return contentString;
             }
 
-            return CompileAndExecuteEmbeddedCode($"treatascontent", contentString) ?? string.Empty;
+            return CompileAndExecuteEmbeddedCode("treatascontent", contentString) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/Sage.Engine/Runtime/StackFrame.cs
+++ b/src/Sage.Engine/Runtime/StackFrame.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using Sage.Engine.Compiler;
 
 namespace Sage.Engine.Runtime
 {
@@ -31,10 +32,7 @@ namespace Sage.Engine.Runtime
             get;
         }
 
-        /// <summary>
-        /// The location where the code exists on disk. May be null for rendering without a file on disk.
-        /// </summary>
-        public FileInfo? CodeFromFile
+        public IContent Content
         {
             get;
         }
@@ -56,11 +54,11 @@ namespace Sage.Engine.Runtime
             set;
         }
 
-        public StackFrame(string name, FileInfo? codeFromFile)
+        public StackFrame(string name, IContent content)
         {
             OutputStream = new StringBuilder();
             Name = name;
-            CodeFromFile = codeFromFile;
+            Content = content;
         }
 
         public StackFrame(string name, string generatedCode)
@@ -70,18 +68,18 @@ namespace Sage.Engine.Runtime
             GeneratedCode = generatedCode;
         }
 
-        private StackFrame(string name, int lineNumber, FileInfo? codeFromFile, string? generatedCode, StringBuilder outputStream)
+        private StackFrame(string name, int lineNumber, IContent content, string? generatedCode, StringBuilder outputStream)
         {
             Name = name;
             CurrentLineNumber = lineNumber;
-            CodeFromFile = codeFromFile;
+            Content = content;
             GeneratedCode = generatedCode;
             OutputStream = new StringBuilder(outputStream.ToString());
         }
 
         public object Clone()
         {
-            return new StackFrame(Name, CurrentLineNumber, CodeFromFile, GeneratedCode, OutputStream);
+            return new StackFrame(Name, CurrentLineNumber, Content, GeneratedCode, OutputStream);
         }
     }
 }

--- a/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
+++ b/src/Sage.Engine/Transpiler/CSharpTranspiler.cs
@@ -20,8 +20,11 @@ namespace Sage.Engine.Transpiler;
 internal class CSharpTranspiler
 {
     /// <summary>
-    /// This is the full path to the input file
+    /// This is the full path to the input file.
     /// </summary>
+    /// <remarks>
+    /// This is used to refer back to the source file for debugging purposes in the #line directive.
+    /// </remarks>
     internal string SourceFileName
     {
         get;
@@ -184,10 +187,16 @@ internal class CSharpTranspiler
     internal MethodDeclarationSyntax GenerateMethodFromCode(string methodName)
     {
         var statements = new List<StatementSyntax>();
-        statements.AddRange(this.BlockVisitor.Visit(this._parser.contentBlock()));
+
+        var results = this.BlockVisitor.Visit(this._parser.contentBlock());
+
+        if (results != null)
+        {
+            statements.AddRange(results);
+        }
 
         // public static string Method(RuntimeContext __runtime)
-        return MethodDeclaration(
+            return MethodDeclaration(
                 PredefinedType(
                     Token(SyntaxKind.VoidKeyword)),
                 Identifier(methodName))

--- a/src/Sage.Webhost/DependencyInjection/SageWebDependencyInjectionExtensions.cs
+++ b/src/Sage.Webhost/DependencyInjection/SageWebDependencyInjectionExtensions.cs
@@ -52,8 +52,7 @@ namespace Sage.Webhost.DependencyInjection
                     appServices.Configure<CompilationOptions>(o =>
                     {
                         o.GeneratedMethodName = CompilerOptionsBuilder.BuildMethodFromFilename(generatedFilename);
-                        o.InputName = generatedFile.Name;
-                        o.InputFile = generatedFile;
+                        o.Content = new LocalFileContent(generatedFile.FullName, 1);
                     });
                     appServices.AddOptions<PackageExtractorOptions>()
                         .Configure<IOptions<SageInMemoryDataOption>, IOptions<ContentOptions>>(
@@ -91,8 +90,7 @@ namespace Sage.Webhost.DependencyInjection
                     appServices.Configure<CompilationOptions>(o =>
                     {
                         o.GeneratedMethodName = CompilerOptionsBuilder.BuildMethodFromFilename(generatedFilename);
-                        o.InputName = generatedFile.Name;
-                        o.InputFile = generatedFile;
+                        o.Content = new LocalFileContent(generatedFile.FullName, 1);
                     });
                     appServices.Configure<ContentOptions>(contentOptions =>
                     {

--- a/src/Sage.Webhost/ExceptionPageRenderer.cs
+++ b/src/Sage.Webhost/ExceptionPageRenderer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, salesforce.com, inc.
+﻿// Copyright (c) 2022, salesforce.com, inc.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
@@ -36,7 +36,7 @@ namespace Sage.Engine
             subscriberExceptionContext["Message"] = generateCodeException.Message;
             subscriberExceptionContext["Stack"] = new JsonArray();
 
-            options.InputFile = _pathToExceptionHtml;
+            options.Content = new LocalFileContent(_pathToExceptionHtml.FullName, 1);
 
             return _renderer.Render(
                 options,
@@ -63,7 +63,7 @@ namespace Sage.Engine
                 jsonFrame["Name"] = frame.Name;
                 jsonFrame["CurrentLineNumber"] = frame.CurrentLineNumber;
                 jsonFrame["Code"] = GetLinesFromCode(frame.CurrentLineNumber,
-                    frame.CodeFromFile ?? throw new FileNotFoundException());
+                    frame.Content ?? throw new FileNotFoundException());
                 callstack.Add(jsonFrame);
             }
 
@@ -71,7 +71,7 @@ namespace Sage.Engine
             subscriberExceptionContext["ExceptionType"] = runtimeException.GetType().Name;
             subscriberExceptionContext["Message"] = runtimeException.Message;
 
-            options.InputFile = _pathToExceptionHtml;
+            options.Content = new LocalFileContent(_pathToExceptionHtml.FullName, 1);
             return _renderer.Render(
                 options,
                 new SubscriberContext(subscriberExceptionContext.ToJsonString()));
@@ -80,9 +80,9 @@ namespace Sage.Engine
         /// <summary>
         /// Gets lines of code near the given line number
         /// </summary>
-        private string GetLinesFromCode(int lineNumber, FileInfo code)
+        private string GetLinesFromCode(int lineNumber, IContent code)
         {
-            string[] lines = File.ReadAllLines(code.FullName);
+            string[] lines = File.ReadAllLines(code.Location);
 
             int start = Math.Max(lineNumber - 3, 0);
             int end = Math.Min(lineNumber + 3, lines.Length);


### PR DESCRIPTION
Many different objects were being used for content compilation, it was awkward to bring around FileInfo, string paths, etc.

This wraps up what is being compiled into an IContent interface that contains all of the metadata about content being compiled.