### PR TITLE
EXPERIMENTAL: Add Handlebars Support

### DIFF
--- a/src/Sage.Engine.Tests/CompilerTests.cs
+++ b/src/Sage.Engine.Tests/CompilerTests.cs
@@ -45,7 +45,10 @@ namespace Sage.Engine.Tests
         }
 
         [Test]
+        [TestCase("%%=ADD(1,2)=%%", ContentType.Handlebars, "%%=ADD(1,2)=%%")]
         [TestCase("%%=ADD(1,2)=%%", ContentType.AMPscript, "3")]
+        [TestCase("{{#if true}}Hello{{/if}}", ContentType.AMPscript, "")]
+        [TestCase("{{#if true}}Hello{{/if}}", ContentType.Handlebars, "Hello")]
         public void TestRenderer(string input, ContentType type, string expected)
         {
             var content = new EmbeddedContent(input, "TEST", "TEST", 1, type);

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/eachHelper.subscribercontext.json
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/eachHelper.subscribercontext.json
@@ -1,0 +1,10 @@
+﻿{
+  "people": [
+    {
+      "name": "Adam"
+    },
+    {
+      "name": "Howard"
+    }
+  ]
+}

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/eachHelper.txt
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/eachHelper.txt
@@ -1,0 +1,6 @@
+﻿===========
+eachHelper
+===========
+{{#each people}}<h1>{{name}}</h1>{{/each}}
+++++++++++
+<h1>Adam</h1><h1>Howard</h1>

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/ifHelper.subscribercontext.json
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/ifHelper.subscribercontext.json
@@ -1,0 +1,4 @@
+﻿{
+  "isActiveFalse": false,
+  "isActiveTrue": true
+}

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/ifHelper.txt
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/ifHelper.txt
@@ -1,0 +1,12 @@
+﻿===========
+If True Block
+===========
+{{#if isActiveTrue}}hello{{else}}world{{/if}}
+++++++++++
+hello
+===========
+If False Block
+===========
+{{#if isActiveFalse}}hello{{else}}world{{/if}}
+++++++++++
+world

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/stringEncoding.subscribercontext.json
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/stringEncoding.subscribercontext.json
@@ -1,0 +1,4 @@
+﻿{
+  "titleTags": "First Template <p> Tags",
+  "titleNoTags": "First Template No Tags"
+}

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/stringEncoding.txt
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/stringEncoding.txt
@@ -1,0 +1,12 @@
+﻿===========
+Escaping
+===========
+{{titleTags}}
+++++++++++
+First Template &lt;p&gt; Tags
+===========
+No Escaping
+===========
+{{titleNoTags}}
+++++++++++
+First Template No Tags

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/unlessHelper.subscribercontext.json
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/unlessHelper.subscribercontext.json
@@ -1,0 +1,4 @@
+﻿{
+  "isActiveTrue": true,
+  "isActiveFalse": false
+}

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/unlessHelper.txt
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/unlessHelper.txt
@@ -1,0 +1,11 @@
+﻿===========
+Unless Helper False
+===========
+{{#unless isActiveFalse}}hello{{/unless}}
+++++++++++
+hello
+===========
+Unless Helper True
+===========
+{{#unless isActiveTrue}}hello{{/unless}}
+++++++++++

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/withHelper.subscribercontext.json
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/withHelper.subscribercontext.json
@@ -1,0 +1,6 @@
+﻿{
+  "primary": {
+    "name": "Adam"
+  },
+  "name": "Howard"
+}

--- a/src/Sage.Engine.Tests/Corpus/Handlebars/withHelper.txt
+++ b/src/Sage.Engine.Tests/Corpus/Handlebars/withHelper.txt
@@ -1,0 +1,6 @@
+﻿===========
+WithHelper Tests
+===========
+{{#with primary}}{{name}}{{/with}}
+++++++++++
+Adam

--- a/src/Sage.Engine.Tests/HandlebarTests.cs
+++ b/src/Sage.Engine.Tests/HandlebarTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2022, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Tests
+{
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Basic tests for the language features and runtime
+    /// </summary>
+    public class HandlebarTests : SageTest
+    {
+        [Test]
+        [RuntimeTest("Handlebars")]
+        public EngineTestResult TestHandlebars(CorpusData test)
+        {
+            try
+            {
+                var result = TestUtils.GetOutputFromHandlebarTest(_serviceProvider, test);
+                Assert.That(result.Output, Is.EqualTo(test.Output));
+                return result;
+            }
+            catch (CompileCodeException e)
+            {
+                Assert.Fail(e.Message);
+                return new EngineTestResult("!");
+            }
+        }
+    }
+}

--- a/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
+++ b/src/Sage.Engine.Tests/Sage.Engine.Tests.csproj
@@ -83,6 +83,36 @@
     <None Update="Corpus\Function\utility.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Corpus\Handlebars\unlessHelper.subscribercontext.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\stringEncoding.subscribercontext.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\ifHelper.subscribercontext.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\eachHelper.subscribercontext.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\eachHelper.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\stringEncoding.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\unlessHelper.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\withHelper.subscribercontext.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\withHelper.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Corpus\Handlebars\ifHelper.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Corpus\Language\attributes.subscribercontext.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Sage.Engine.Tests/TestUtils.cs
+++ b/src/Sage.Engine.Tests/TestUtils.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, salesforce.com, inc.
+﻿// Copyright (c) 2022, salesforce.com, inc.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
@@ -6,7 +6,6 @@
 using Antlr4.Runtime.Tree;
 using Microsoft.Extensions.DependencyInjection;
 using Sage.Engine.Compiler;
-using Sage.Engine.Data;
 using Sage.Engine.Parser;
 using Sage.Engine.Runtime;
 
@@ -41,6 +40,27 @@ public static class TestUtils
             test.SubscriberContext);
     }
     
+
+    /// <summary>
+    /// Uses Handlebars to compile the content instead of the AMPscript compiler
+    /// </summary>
+    public static EngineTestResult GetOutputFromHandlebarTest(IServiceProvider serviceProvider, CorpusData test)
+    {
+        CompilationOptions options = new CompilerOptionsBuilder()
+            .WithContent(new EmbeddedContent(test.Code, test.FileFriendlyName, test.FileFriendlyName, 1, ContentType.Handlebars))
+            .Build();
+ 
+        try
+        {
+            string result = serviceProvider.GetService<ICompiler>()
+                !.Compile(options, GetTestRuntimeContext(serviceProvider, options, test), test.SubscriberContext);
+            return new EngineTestResult(result.ReplaceLineEndings("\n").Trim());
+        }
+        catch (Exception)
+        {
+            return new EngineTestResult("!");
+        }
+    }
 
     /// <summary>
     /// Executes the engine and gets the expected result from the engine

--- a/src/Sage.Engine/Content/ContentExtensions.cs
+++ b/src/Sage.Engine/Content/ContentExtensions.cs
@@ -46,6 +46,13 @@ namespace Sage.Engine.Compiler
         /// </summary>
         public static ContentType InferContentTypeFromFilename(string path)
         {
+            string extension = Path.GetExtension(path).ToLowerInvariant();
+
+            if (extension == ".hbs")
+            {
+                return ContentType.Handlebars;
+            }
+
             return ContentType.AMPscript;
         }
     }

--- a/src/Sage.Engine/Content/IContent.cs
+++ b/src/Sage.Engine/Content/IContent.cs
@@ -10,7 +10,8 @@ namespace Sage.Engine.Compiler
     /// </summary>
     public enum ContentType
     {
-        AMPscript
+        AMPscript,
+        Handlebars
     };
 
     /// <summary>

--- a/src/Sage.Engine/Content/LocalDiskContentClient.cs
+++ b/src/Sage.Engine/Content/LocalDiskContentClient.cs
@@ -61,6 +61,12 @@ namespace Sage.Engine.Content
                 return new LocalFileContent(id, filePath, 1, ContentType.AMPscript);
             }
 
+            filePath = Path.Combine(_options.InputDirectory.FullName, $"{id}.hbs");
+            if (File.Exists(filePath))
+            {
+                return new LocalFileContent(id, filePath, 1, ContentType.Handlebars);
+            }
+
             return null;
         }
     }

--- a/src/Sage.Engine/DependencyInjection/SageDependencyInjectionExtensions.cs
+++ b/src/Sage.Engine/DependencyInjection/SageDependencyInjectionExtensions.cs
@@ -10,6 +10,7 @@ using Sage.Engine.Compiler;
 using Sage.Engine.Data.DependencyInjection;
 using Sage.Engine.Data.Sqlite;
 using Sage.Engine.Extensions;
+using Sage.Engine.Handlebars;
 
 namespace Sage.Engine.DependencyInjection
 {
@@ -61,6 +62,7 @@ namespace Sage.Engine.DependencyInjection
             services.AddLocalDiskContentClient();
             services.AddScoped<Renderer>();
             services.AddScoped<ICompiler, AmpscriptCompiler>();
+            services.AddScoped<ICompiler, HandlebarsCompiler>();
         }
     }
 }

--- a/src/Sage.Engine/Handlebars/HandlebarsCompiler.cs
+++ b/src/Sage.Engine/Handlebars/HandlebarsCompiler.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2023, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+using HandlebarsDotNet;
+using HandlebarsDotNet.Extension.Json;
+using Sage.Engine.Compiler;
+using Sage.Engine.Runtime;
+
+namespace Sage.Engine.Handlebars
+{
+    /// <summary>
+    /// Uses HandlebarsDotNet to compile content to a string.
+    ///
+    /// Does not support AMPscript embedded in the content.
+    /// </summary>
+    internal class HandlebarsCompiler : IHandlebarsCompiler
+    {
+        private IHandlebars _handlebar;
+
+        public HandlebarsCompiler()
+        {
+            _handlebar = HandlebarsDotNet.Handlebars.Create();
+            _handlebar.Configuration.UseJson();
+        }
+
+        public bool CanCompile(IContent content)
+        {
+            return content.ContentType == ContentType.Handlebars;
+        }
+
+        public string Compile(CompilationOptions options, RuntimeContext runtimeContext, SubscriberContext? subscriberContext)
+        {
+            var template = _handlebar.Compile(options.Content.GetTextReader());
+
+            StringWriter writer = new StringWriter();
+
+            template(writer, subscriberContext?.GetRichAttributes());
+
+            return writer.ToString();
+        }
+    }
+}

--- a/src/Sage.Engine/Handlebars/IHandlebarsCompiler.cs
+++ b/src/Sage.Engine/Handlebars/IHandlebarsCompiler.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2023, salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
+
+namespace Sage.Engine.Handlebars
+{
+    /// <summary>
+    /// Renders a piece of Handlebars content to a string.
+    /// </summary>
+    public interface IHandlebarsCompiler : ICompiler
+    {
+    }
+}

--- a/src/Sage.Engine/Runtime/RuntimeContext.cs
+++ b/src/Sage.Engine/Runtime/RuntimeContext.cs
@@ -49,21 +49,8 @@ namespace Sage.Engine.Runtime
             _contentBuilderContentClient = provider.GetRequiredService<IContentBuilderContentClient>();
             _dataExtensionClient = provider.GetRequiredService<IDataExtensionClient>();
             _dataExtensionClient.ConnectAsync().Wait();
-
-            string subscriberContextFile =
-                Path.Combine(Path.GetDirectoryName(_rootCompilationOptions.Content.Location), "subscriber.json");
-            if (subscriberContext != null)
-            {
-                _subscriberContext = subscriberContext;
-            }
-            else if (Path.Exists(subscriberContextFile))
-            {
-                _subscriberContext = new SubscriberContext(File.ReadAllText(subscriberContextFile));
-            }
-            else
-            {
-                _subscriberContext = new SubscriberContext(null);
-            }
+            
+            _subscriberContext = subscriberContext ?? new SubscriberContext(null);
 
             _stackFrame.Push(new StackFrame(_rootCompilationOptions.GeneratedMethodName, _rootCompilationOptions.Content));
         }
@@ -229,7 +216,6 @@ namespace Sage.Engine.Runtime
 
         internal string? CompileAndExecuteReferencedCode(CompilationOptions currentOptions)
         {
-            CompileResult compileResult = CSharpCompiler.GenerateAssemblyFromSource(currentOptions);
 
             string poppedContext;
 
@@ -237,6 +223,8 @@ namespace Sage.Engine.Runtime
 
             try
             {
+                
+                CompileResult compileResult = CSharpCompiler.GenerateAssemblyFromSource(currentOptions);
                 compileResult.Execute(this);
             }
             finally

--- a/src/Sage.Engine/Runtime/SubscriberContext.cs
+++ b/src/Sage.Engine/Runtime/SubscriberContext.cs
@@ -14,7 +14,9 @@ namespace Sage.Engine.Runtime
     /// </summary>
     public class SubscriberContext
     {
-        private readonly JsonNode? _context;
+        // TODO: This should be updated to only parse once
+        private readonly JsonNode? _contextNode;
+        private readonly JsonDocument? _contextDocument;
 
         public SubscriberContext(string? context)
         {
@@ -27,12 +29,13 @@ namespace Sage.Engine.Runtime
             {
                 PropertyNameCaseInsensitive = true
             };
-            _context = JsonNode.Parse(context, options);
+            _contextNode = JsonNode.Parse(context, options);
+            _contextDocument = JsonDocument.Parse(context);
         }
 
         public object? GetAttribute(string attributeName)
         {
-            var result = _context?[attributeName];
+            var result = _contextNode?[attributeName];
 
             if (result == null)
             {
@@ -42,9 +45,20 @@ namespace Sage.Engine.Runtime
             return result;
         }
 
+        /// <summary>
+        /// Returns a flat, non-nested set of subscriber attributes as a key/value pair of strings.
+        /// </summary>
         public Dictionary<string, string> GetAttributes()
         {
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(_context);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(_contextNode) ?? new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Enables "rich" attributes, which can be complete JSON documents
+        /// </summary>
+        public JsonDocument? GetRichAttributes()
+        {
+            return _contextDocument;
         }
     }
 }

--- a/src/Sage.Engine/Sage.Engine.csproj
+++ b/src/Sage.Engine/Sage.Engine.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Antlr4BuildTasks" Version="12.7.0" PrivateAssets="all" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+    <PackageReference Include="Handlebars.Net.Extension.Json" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/Sage.Webhost/Properties/launchSettings.json
+++ b/src/Sage.Webhost/Properties/launchSettings.json
@@ -22,13 +22,23 @@
     },
     "Ampscript ": {
       "commandName": "Project",
-      "commandLineArgs": "ampscript --source \"C:\\code\\AmpscriptFiles\\dd4tmp.ampscript\"",
-      "workingDirectory": "C:\\code\\AmpscriptFiles",
+      "commandLineArgs": "ampscript --source \"C:\\code\\AmpscriptFiles\\dd4tmp\\dd4tmp.ampscript\"",
+      "workingDirectory": "C:\\code\\AmpscriptFiles\\dd4tmp",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7194"
+    },
+    "HBS": {
+      "commandName": "Project",
+      "commandLineArgs": "ampscript --source \"C:\\code\\AmpscriptFiles\\dd4tmp-hbs\\dd4tmp.hbs\"",
+      "workingDirectory": "C:\\code\\AmpscriptFiles\\dd4tmp",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
       "applicationUrl": "https://localhost:7194"
     }
   },

--- a/src/Sage.Webhost/WebRequestRenderer.cs
+++ b/src/Sage.Webhost/WebRequestRenderer.cs
@@ -1,10 +1,11 @@
-// Copyright (c) 2022, salesforce.com, inc.
+﻿// Copyright (c) 2022, salesforce.com, inc.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/Apache-2.0
 
 using Microsoft.Extensions.Options;
 using Sage.Engine.Compiler;
+using Sage.Engine.Runtime;
 using Sage.Webhost;
 
 namespace Sage.Engine
@@ -33,7 +34,14 @@ namespace Sage.Engine
         {
             try
             {
-                return _renderer.Render(inputOption);
+                SubscriberContext context = null;
+                string subscriberContextFile = Path.Combine(Path.GetDirectoryName(inputOption.Content.Location), "subscriber.json");
+                if (Path.Exists(subscriberContextFile))
+                {
+                    context = new SubscriberContext(File.ReadAllText(subscriberContextFile));
+                }
+
+                return _renderer.Render(inputOption, context);
             }
             catch (GenerateCodeException compileException)
             {

--- a/src/vscode/package-lock.json
+++ b/src/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ampscript",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ampscript",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.7.7",
         "fs-extra": "9.1.0",

--- a/src/vscode/package.json
+++ b/src/vscode/package.json
@@ -3,7 +3,7 @@
   "publisher": "salesforce",
   "displayName": "AMPscript Editor",
   "description": "Locally run AMPscript, powered by AMPscript Core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.74.0"
   },
@@ -39,6 +39,12 @@
           ".ampscript"
         ],
         "configuration": "./syntaxes/language-configuration.json"
+      },
+      {
+        "id": "handlebars",
+        "extensions": [
+          ".hbs"
+        ]
       }
     ],
     "grammars": [
@@ -58,12 +64,13 @@
         "type": "ampscript",
         "languages": [
           "ampscript",
-          "json"
+          "json",
+          "handlebars"
         ],
-        "label": "Debug AMPscript",
+        "label": "Debug With AMPscript Core",
         "configurationSnippets": [
         {
-          "label": "AMPscript: Debug the current AMPscript file",
+          "label": "AMPscript: Debug the current AMPscript Core file",
           "description": "Launch an AMPscript file with a debugger.",
           "body": {
             "name": "AMPscript launch",

--- a/src/vscode/src/main.ts
+++ b/src/vscode/src/main.ts
@@ -78,6 +78,9 @@ export class AmpscriptConfigurationProvider implements vscode.DebugConfiguration
             } else if (editor.document.languageId === 'ampscript') {
                 config.args = "ampscript --source ${file}";
                 reporter.sendTelemetryEvent("launch", {'type': 'ampscriptfile'});
+            } else if (editor.document.languageId === 'handlebars') {
+                config.args = "ampscript --source ${file}";
+                reporter.sendTelemetryEvent("launch", {'type': 'handlebars'});
             }
         }
 


### PR DESCRIPTION
Prototyping and exploration of what Handlebars would look like.

Handlebars.Net as the supported engine
Handlebar content can be rendered using files with `.hbs` extension in VSCode extension. Enables nested JSON types in the attributes to support more complex attributes